### PR TITLE
fix(github-actions): fix CVE-2025-30066 and pre-emptive security measures

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,11 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: read-all
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   detect-changes:
@@ -36,7 +37,7 @@ jobs:
 
     - name: Determine what files types have changed
       id: changed-files-yaml
-      uses: tj-actions/changed-files@0e58ed8671d6b60d0890c21b07f8835ace038e67 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           actions:

--- a/.github/workflows/scan-pr.yaml
+++ b/.github/workflows/scan-pr.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@0e58ed8671d6b60d0890c21b07f8835ace038e67 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           terraform:

--- a/modules/github-repository/environments.tf
+++ b/modules/github-repository/environments.tf
@@ -1,0 +1,34 @@
+locals {
+  flattened_secrets = flatten([
+    for env_name, secrets in var.environment_secrets : [
+      for secret_name, secret_value in secrets : {
+        env_name     = env_name
+        secret_name  = secret_name
+        secret_value = secret_value
+      }
+    ]
+  ])
+
+  secrets_map = {
+    for secret in local.flattened_secrets :
+    "${secret.env_name}.${secret.secret_name}" => secret
+  }
+}
+
+resource "github_repository_environment" "environments" {
+  for_each    = var.environment_secrets
+  environment = each.key
+  repository  = github_repository.repository.name
+}
+
+resource "github_actions_environment_secret" "environment_secrets" {
+  for_each        = local.secrets_map
+  environment     = each.value.env_name
+  repository      = github_repository.repository.name
+  secret_name     = replace(upper(each.value.secret_name), "-", "_")
+  plaintext_value = each.value.secret_value
+
+  depends_on = [
+    github_repository_environment.environments
+  ]
+}

--- a/modules/github-repository/variables.tf
+++ b/modules/github-repository/variables.tf
@@ -8,6 +8,12 @@ variable "actions_allowed" {
   default = []
 }
 
+variable "environment_secrets" {
+  description = "Map of environment names to their secrets (secret_name -> secret_value)"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "force_push_bypassers" {
   type    = list(string)
   default = []

--- a/workspaces/github/repo-homelab-ops-ansible.tf
+++ b/workspaces/github/repo-homelab-ops-ansible.tf
@@ -9,13 +9,11 @@ module "repo_homelab_ops_ansible" {
     "jdx/mise-action@*",
     "tj-actions/changed-files@*"
   ]
-  actions_secrets = {
-    HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
-    HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
-    # TODO: add these
-    # ANSIBLE_GALAXY_API_TOKEN
-    # FLUX_REPO_READER_SSH_KEY
-    # GH_RELEASE_TOKEN
+  environment_secrets = {
+    release = {
+      ANSIBLE_GALAXY_API_TOKEN = var.ansible_galaxy_api_token
+      GH_RELEASE_TOKEN         = var.gh_release_token
+    }
   }
   topics = [
     "ansible",

--- a/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
+++ b/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
@@ -18,8 +18,10 @@ module "repo_homelab_ops_kubernetes_apps" {
     "mshick/add-pr-comment@*",
     "tj-actions/changed-files@*"
   ]
-  actions_secrets = {
-    HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
-    HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
+  environment_secrets = {
+    release = {
+      HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
+      HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
+    }
   }
 }

--- a/workspaces/github/repo-homelab-ops-packer.tf
+++ b/workspaces/github/repo-homelab-ops-packer.tf
@@ -10,15 +10,15 @@ module "repo_homelab_ops_packer" {
     "tailscale/github-action@*",
     "tj-actions/changed-files@*"
   ]
-  actions_secrets = {
-    HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
-    HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
-    # TODO: add these
-    # ARTIFACT_SERVER_HOST
-    # ARTIFACT_SERVER_PASSWORD
-    # ARTIFACT_SERVER_PATH
-    # ARTIFACT_SERVER_USER
-    # TAILSCALE_OAUTH_CLIENT_ID
-    # TAILSCALE_OAUTH_SECRET
+  environment_secrets = {
+    release = {
+      # TODO: add these
+      # ARTIFACT_SERVER_HOST
+      # ARTIFACT_SERVER_PASSWORD
+      # ARTIFACT_SERVER_PATH
+      # ARTIFACT_SERVER_USER
+      # TAILSCALE_OAUTH_CLIENT_ID
+      # TAILSCALE_OAUTH_SECRET
+    }
   }
 }

--- a/workspaces/github/repo-homelab-ops-terraform.tf
+++ b/workspaces/github/repo-homelab-ops-terraform.tf
@@ -12,10 +12,7 @@ module "repo_homelab_ops_terraform" {
     "jdx/mise-action@*",
     "tj-actions/changed-files@*"
   ]
-  actions_secrets = {
-    HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
-    HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
-  }
+  # force_push_bypassers = [data.github_user.current.node_id]
   #   required_status_checks = [
   #     "Snyk Security Check",
   #     "terraform-fmt",

--- a/workspaces/github/repo-images.tf
+++ b/workspaces/github/repo-images.tf
@@ -6,7 +6,9 @@ module "repo_images" {
     visibility  = "public"
   }
   actions_allowed = [
-    "aquaproj/update-checksum-workflow@*",
+    "aquaproj/aqua-installer@*",
+    "aquaproj/update-checksum-action@*",
+    "aquaproj/update-checksum-workflow/.github/workflows/update-checksum.yaml@*",
     "docker/build-push-action@*",
     "docker/setup-buildx-action@*",
     "docker/login-action@*",
@@ -15,20 +17,22 @@ module "repo_images" {
     "hadolint/hadolint-action@*",
     "jdx/mise-action@*",
     "peter-evans/dockerhub-description@*",
+    "suzuki-shunsuke/github-token-action@*",
     "tailscale/github-action@*",
+    "tibdex/github-app-token@*",
     "tj-actions/changed-files@*"
   ]
   actions_secrets = {
+    # TODO: re-enable and fix
+    # CONTAINER_REGISTRY          = "harbor.nas.${var.dns_zone}"
+    # CONTAINER_REGISTRY_USERNAME = var.harbor_username
+    # CONTAINER_REGISTRY_PASSWORD = var.harbor_password
+    DOCKERHUB_USERNAME          = var.dockerhub_username
+    DOCKERHUB_TOKEN             = var.dockerhub_token
     HOMELAB_BOT_APP_ID          = var.homelab_bot_app_id
     HOMELAB_BOT_APP_PRIVATE_KEY = file(var.homelab_bot_app_private_key)
-    # TODO: add these
-    # CONTAINER_REGISTRY
-    # CONTAINER_REGISTRY_PASSWORD
-    # CONTAINER_REGISTRY_USERNAME
-    # DOCKERHUB_TOKEN
-    # DOCKERHUB_USERNAME
-    # TAILSCALE_OAUTH_CLIENT_ID
-    # TAILSCALE_OAUTH_SECRET
+    TAILSCALE_OAUTH_CLIENT_ID   = var.clientid_tailscale
+    TAILSCALE_OAUTH_SECRET      = var.clientsecret_tailscale
   }
   homepage_url = "https://hub.docker.com/u/ppatlabs"
   topics = [

--- a/workspaces/github/variables.tf
+++ b/workspaces/github/variables.tf
@@ -7,3 +7,50 @@ variable "homelab_bot_app_private_key" {
   type      = string
   sensitive = true
 }
+
+variable "gh_release_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "ansible_galaxy_api_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "dockerhub_username" {
+  type      = string
+  sensitive = true
+}
+
+variable "dockerhub_token" {
+  type      = string
+  sensitive = true
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "harbor_username" {
+  type      = string
+  sensitive = true
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "harbor_password" {
+  type      = string
+  sensitive = true
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "dns_zone" {
+  type = string
+}
+
+variable "clientid_tailscale" {
+  type      = string
+  sensitive = true
+}
+
+variable "clientsecret_tailscale" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
- Fix CVE-2025-30066 by upgrading to tj-actions/changed-files to v46
- Rotate all secrets used in Github Actions
- Setup pre-emptive measures to limit the blast radius of future vulnerabilities in github actions
  - explicitly set permission for default GITHUB_TOKEN to limit its capabilities to only whats needed
  - Move repository wide secrets to environments when possible and set environments explicitly on jobs that need those secrets