### PR TITLE
feat(github-repository): enable turning off signed commits

### DIFF
--- a/modules/github-repository/branch-protection.tf
+++ b/modules/github-repository/branch-protection.tf
@@ -7,7 +7,7 @@ resource "github_branch_protection" "main" {
   force_push_bypassers            = var.force_push_bypassers
   require_conversation_resolution = false
   required_linear_history         = true
-  require_signed_commits          = true
+  require_signed_commits          = var.require_signed_commits
 
   required_status_checks {
     strict   = true

--- a/modules/github-repository/variables.tf
+++ b/modules/github-repository/variables.tf
@@ -32,6 +32,11 @@ variable "repository" {
   })
 }
 
+variable "require_signed_commits" {
+  type    = bool
+  default = true
+}
+
 variable "required_status_checks" {
   type    = list(string)
   default = []


### PR DESCRIPTION
- This is primarily for repositories w/ release tools that do not make signed commits out of the box