### PR TITLE
feat(github): add obsidian-tools image-build secrets and variables

### DIFF
--- a/workspaces/github/repo-obsidian-tools.tf
+++ b/workspaces/github/repo-obsidian-tools.tf
@@ -1,0 +1,36 @@
+module "repo_obsidian_tools" {
+  source = "../../modules/github-repository"
+  repository = {
+    name        = "obsidian-tools"
+    description = ""
+    visibility  = "private"
+  }
+  actions_allowed = [
+    "docker/build-push-action@*",
+    "docker/setup-buildx-action@*",
+    "docker/login-action@*",
+    "docker/metadata-action@*",
+    "docker/setup-qemu-action@*",
+    "googleapis/release-please-action@*",
+    "jdx/mise-action@*",
+    "tailscale/github-action@*",
+    "tj-actions/changed-files@*"
+  ]
+  actions_secrets = {
+    CONTAINER_REGISTRY          = "harbor.nas.${data.bitwarden_secret.dns_zone.value}"
+    CONTAINER_REGISTRY_USERNAME = data.bitwarden_secret.harbor_robot_username.value
+    CONTAINER_REGISTRY_PASSWORD = data.bitwarden_secret.harbor_robot_password.value
+    DOCKERHUB_USERNAME          = data.bitwarden_secret.dockerhub_username.value
+    DOCKERHUB_TOKEN             = data.bitwarden_secret.dockerhub_token.value
+    HOMELAB_BOT_APP_ID          = data.bitwarden_secret.homelab_bot_app_id.value
+    HOMELAB_BOT_APP_PRIVATE_KEY = data.bitwarden_secret.homelab_bot_app_private_key.value
+    RENOVATE_APP_ID             = data.bitwarden_secret.renovate_app_id.value
+    RENOVATE_APP_PRIVATE_KEY    = data.bitwarden_secret.renovate_app_private_key.value
+    TAILSCALE_OAUTH_CLIENT_ID   = data.bitwarden_secret.tailscale_githubactionsci_clientid.value
+    TAILSCALE_OAUTH_SECRET      = data.bitwarden_secret.tailscale_githubactionsci_clientsecret.value
+  }
+  actions_variables = {
+    CONTAINER_REGISTRY_CACHE_PATH = "build-cache"
+    CONTAINER_REGISTRY_PATH       = "library"
+  }
+}


### PR DESCRIPTION
## Summary

`ppat/obsidian-tools` is about to start calling `ppat/github-workflows`'
`build-docker-image.yaml` reusable workflow directly from its own CI — the
same pattern `ppat/coder` already uses — instead of routing image builds
through `ppat/images`. That build will fail at credential-minting time
because the repo currently has no GitHub Actions secrets/variables for the
private container registry or Tailscale CI runner. This PR unblocks that
build.

- Add `CONTAINER_REGISTRY`, `CONTAINER_REGISTRY_USERNAME`,
  `CONTAINER_REGISTRY_PASSWORD`, `TAILSCALE_OAUTH_CLIENT_ID`,
  `TAILSCALE_OAUTH_SECRET` to `actions_secrets`.
- Add `CONTAINER_REGISTRY_PATH` / `CONTAINER_REGISTRY_CACHE_PATH` to
  `actions_variables`, set to `"library"` / `"build-cache"` — the only two
  Harbor projects the shared CI robot account (`harbor_robot_username` /
  `harbor_robot_password`) actually has permissions on
  (`workspaces/harbor/robot-accounts.tf`), matching what `repo-images.tf`
  and `repo-github-workflows.tf` already use.
- Add `docker/build-push-action`, `docker/setup-buildx-action`,
  `docker/login-action`, `docker/metadata-action`, `docker/setup-qemu-action`,
  and `tailscale/github-action` to `actions_allowed`, mirroring
  `repo-coder.tf`.

**No new Bitwarden secrets were created.** Every value above reuses a
`data.bitwarden_secret` already declared in `workspaces/github/secrets.tf`
(`dns_zone`, `harbor_robot_username`, `harbor_robot_password`,
`tailscale_githubactionsci_clientid`, `tailscale_githubactionsci_clientsecret`).

`obsidian-tools` is private and its image must stay private: this PR does
**not** add `peter-evans/dockerhub-description` or any Docker Hub *publish*
wiring, so the shared workflow's `PUBLISH_DOCKERHUB` gate can never be true
for this repo — only the private registry path is enabled. The existing
`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets (present for unrelated
reasons) are left untouched.

## This is the first commit of `repo-obsidian-tools.tf` — review it as a whole file, not a diff

`repo-obsidian-tools.tf` was present locally only as an **untracked file**, absent from
`origin/main` entirely (`git show origin/main:workspaces/github/repo-obsidian-tools.tf`
reports it missing). So this PR is the file's first commit, carrying its existing
Docker Hub / bot-app / Renovate baseline forward unchanged alongside the new additions,
rather than an incremental diff against a merged baseline.

**What is actually going on, corrected.** An earlier revision of this PR body inferred that
those baseline secrets had been applied from an uncommitted working copy, and warned that an
apply from a clean checkout could destroy them. **That inference was wrong.** The apply
failed; the six baseline secrets were then **set by hand** on both repos as a workaround —
which is why release-please and Renovate work today despite the config never having been
committed or applied.

So the resources are almost certainly **not in Terraform state**, and applying this changes
nothing destructively: it creates them properly and reconciles the hand-set values against
the ones sourced from Bitwarden.

**The real problem is incompleteness.** Exactly the secrets release-please and Renovate need
were hand-set, so those work and look healthy. The registry and Tailscale credentials an
image build needs were never added — and their absence **does not fail the build, it
silently skips the push**. `ppat/obsidian-tools#22`'s `build-image` check passed in 1m24s and
produced no image; buildx warned that the result would "only remain in the build cache," and
the resolved tag came out as a bare `branch-git-committer` with no repository prefix, because
the registry secret was empty. A manifest in another repo is currently pinned to a Harbor tag
that has never existed.

**Applying this PR is what makes that image real.** That is the actual reason to merge it,
and it is more urgent than the tidiness argument.

`repo-obsidian-vault.tf` is in the **same state** — untracked, with the same six secrets
hand-set on `ppat/obsidian-vault`. Outside this PR's scope and left untouched, but it wants
its own commit.

## Test plan

- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` (via a fresh `-backend=false` init, since the
      local `workspaces/github/.terraform` had real S3/MinIO backend state
      requiring credentials not available in this environment) — passes
      with only a pre-existing, unrelated `bitwarden` provider deprecation
      warning
- [x] `tflint --config=.tflint.hcl` — clean
- [x] `pre-commit run --files workspaces/github/repo-obsidian-tools.tf`
      (fmt, validate, tflint, checkov, gitleaks) — all passed
- [ ] `terraform plan` was **not** run against real state — no credentials
      for the real backend/GitHub provider in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

