### PR TITLE
fix(github): stop requiring signed commits on obsidian-vault

### DIFF
--- a/workspaces/github/repo-obsidian-vault.tf
+++ b/workspaces/github/repo-obsidian-vault.tf
@@ -5,4 +5,18 @@ module "repo_obsidian_vault" {
     description = ""
     visibility  = "private"
   }
+  # The only writer is a machine: the vault's git committer, pushing derived history on a schedule
+  # with a deploy key scoped to this repository alone (ppat/obsidian-tools#3). Requiring verified
+  # signatures here would block it -- and buy nothing, because the signature would be made with the
+  # same key an attacker would have to steal to push in the first place. That is provenance display,
+  # not a second factor.
+  #
+  # Making it genuinely "Verified" would also cost more than it looks: GitHub only verifies an SSH
+  # signature when the signing key belongs to an account AND the commit email is a verified address
+  # on that account, so the committer would have to author as a human. The vault's whole provenance
+  # model rests on telling machine writes from human ones, so that trade is backwards here.
+  #
+  # Revisit if this repository ever gains a second writer, or if the committer is given a signing
+  # key distinct from its auth key -- at that point signing would mean something.
+  require_signed_commits = false
 }


### PR DESCRIPTION
Sets `require_signed_commits = false` on `ppat/obsidian-vault`. The module defaults it to `true` and this repository never overrode it; `repo-coder.tf` and `repo-homelab-ops-ansible.tf` are the existing precedent for `false`.

## Why

The vault's git committer is now deployed and pushing derived history on a schedule. Its first real push was rejected:

```
GH006: Protected branch update failed for refs/heads/main.
- Commits must have verified signatures.
```

**The only writer to this repository is a machine**, authenticating with a deploy key scoped to this repository alone. Requiring verified signatures blocks it and buys nothing: the signature would be made with **the same key an attacker would have to steal in order to push at all**. That is provenance display, not a second factor.

Making it genuinely `Verified` would also cost more than it first appears. GitHub only verifies an SSH signature when the signing key belongs to an account **and** the commit's email is a verified address on that account — so the committer would have to author as a human. The vault's entire provenance model rests on distinguishing machine writes from human ones (`source`, `authority`, `trigger`), so trading that away to satisfy a branch rule is backwards.

## When to revisit

Two conditions would make signing meaningful, and both are noted in the code:

- the repository gains a second writer, so a signature actually distinguishes something; or
- the committer is given a **signing key distinct from its auth key**, so compromise of one does not yield the other.

## Note on immediate state

The setting has been toggled off by hand so the committer can push now. Without this change the next `terraform apply` would silently turn it back on and the committer would start failing again — this is what makes the manual change durable.

## Verification

`terraform fmt` clean. `terraform validate` could not run here: the Bitwarden provider requires credentials this environment does not have, and it fails identically on files this PR does not touch (confirmed against an unmodified `repo-coder.tf`). No validate error references the changed file. The `terraform-validate` pre-commit hook was skipped for that reason alone; every other hook ran.
