### PR TITLE
fix(github): require core CI checks on homelab-ops-kubernetes-apps main

### DIFF
--- a/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
+++ b/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
@@ -13,8 +13,7 @@ module "repo_homelab_ops_kubernetes_apps" {
   ]
   # #3416 and #3417 are both merged and confirmed green on main (kubernetes-manifests
   # re-verified directly via workflow_dispatch against main's tip; detect-changes and
-  # pre-commit confirmed in the same run; commit-messages is PR-only by design and has
-  # passed repeatedly across every PR opened this session). Safe to apply.
+  # pre-commit confirmed in the same run). Safe to apply.
   #
   # This list is deliberately NOT every job in lint.yaml. A GitHub Actions job's check-run
   # *name* is only stable across every PR if either (a) it has no job-level `if:` at all,
@@ -41,15 +40,20 @@ module "repo_homelab_ops_kubernetes_apps" {
   #      lint.yaml (aggregating `needs.*.result` with `if: always()`) before those five
   #      can be safely required - not something this Terraform list alone can solve.
   #
-  # The four below are unaffected by either failure mode: `kubernetes-manifests` has no
-  # reusable-workflow call at all (inline job, name never has a slash);
-  # `detect-changes`/`pre-commit` have no job-level `if:`; `commit-messages`'s only gate
-  # is `event_name == 'pull_request'`, true for every real PR event.
+  # The three below are unaffected by either failure mode: `kubernetes-manifests` has no
+  # reusable-workflow call at all (inline job, name never has a slash); `detect-changes`/
+  # `pre-commit` have no job-level `if:` at all.
+  #
+  # `commit-messages / commit-messages` is ALSO name-stable (its only gate is
+  # `event_name == 'pull_request'`, true for every real PR) but deliberately left out
+  # anyway: Renovate-authored commits sometimes fail commitlint, and making this required
+  # would block those PRs - including automerge - on a lint failure in a commit message
+  # neither this repo nor Renovate's own config fully controls. Revisit only if that
+  # gets fixed at the source (Renovate commit-message template / commitlint config).
   required_status_checks = [
     "kubernetes-manifests",
     "detect-changes / detect-changed-files",
-    "pre-commit / pre-commit",
-    "commit-messages / commit-messages"
+    "pre-commit / pre-commit"
   ]
   actions_secrets = {
     DOCKERHUB_USERNAME          = data.bitwarden_secret.dockerhub_username.value

--- a/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
+++ b/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
@@ -11,21 +11,45 @@ module "repo_homelab_ops_kubernetes_apps" {
     "jdx/mise-action@*",
     "tj-actions/changed-files@*"
   ]
-  # DO NOT APPLY until ppat/homelab-ops-kubernetes-apps#3416 and #3417 are both fixed
-  # AND confirmed reliably green on that repo's `main` - see PR description for why.
+  # #3416 and #3417 are both merged and confirmed green on main (kubernetes-manifests
+  # re-verified directly via workflow_dispatch against main's tip; detect-changes and
+  # pre-commit confirmed in the same run; commit-messages is PR-only by design and has
+  # passed repeatedly across every PR opened this session). Safe to apply.
   #
-  # Only `kubernetes-manifests` is listed: it's a single, fixed-name job with no
-  # matrix, so it always reports a check for every PR. The `diff-changes.yaml`
-  # workflow's `diff` job (the #3417 checks) uses a *dynamic* `module x resource`
-  # matrix derived from which modules a given PR touches - e.g. `diff (infra-database,
-  # helmrelease)` only exists on PRs that touch infra-database. Naming any of those
-  # matrix entries here would make GitHub wait forever ("Expected") on PRs that never
-  # produce that specific combination, permanently blocking their merge. There's no
-  # aggregator/gate job over the diff matrix to point at instead (verified by reading
-  # .github/workflows/diff-changes.yaml directly) - adding one is a separate follow-up
-  # if the diff checks should ever become required.
+  # This list is deliberately NOT every job in lint.yaml. A GitHub Actions job's check-run
+  # *name* is only stable across every PR if either (a) it has no job-level `if:` at all,
+  # or (b) its `if:` is unconditionally true for every `pull_request` event. Two distinct
+  # ways a job can fail that test, both confirmed against real runs on this repo:
+  #
+  #   1. Workflow-level `paths:` filters (diff-changes.yaml's `diff` job, and every
+  #      chainsaw `test-*.yaml` workflow) mean the workflow never triggers at all for a
+  #      PR that doesn't touch matching paths - zero check runs posted, so a required
+  #      check on any of their job names gets stuck "Expected" forever on unrelated PRs.
+  #      diff-changes.yaml also stacks a *dynamic* module x resource matrix on top (post
+  #      #3515), making individual `diff (<module>, <resource>)` names even less stable.
+  #
+  #   2. Job-level `if:` gating a *reusable workflow call* (lint.yaml's `github-actions`,
+  #      `markdown`, `renovate-config-check`, `shellcheck`, `yaml` jobs - all gated on
+  #      `fromJSON(needs.detect-changes.outputs.results).<bucket>_any_changed`) changes
+  #      the check-run *name itself* depending on whether the job actually invoked the
+  #      reusable workflow: it reports as bare `shellcheck` when skipped, but
+  #      `shellcheck / shellcheck` when it actually runs - two genuinely different
+  #      context strings from GitHub's point of view, confirmed via the raw Checks API
+  #      (not just the CLI display) against a real PR. Classic branch protection has no
+  #      OR-semantics, so requiring both strings doesn't help - it'd just permanently wait
+  #      on whichever one didn't fire. Fixing this needs an always-run gate job in
+  #      lint.yaml (aggregating `needs.*.result` with `if: always()`) before those five
+  #      can be safely required - not something this Terraform list alone can solve.
+  #
+  # The four below are unaffected by either failure mode: `kubernetes-manifests` has no
+  # reusable-workflow call at all (inline job, name never has a slash);
+  # `detect-changes`/`pre-commit` have no job-level `if:`; `commit-messages`'s only gate
+  # is `event_name == 'pull_request'`, true for every real PR event.
   required_status_checks = [
-    "kubernetes-manifests"
+    "kubernetes-manifests",
+    "detect-changes / detect-changed-files",
+    "pre-commit / pre-commit",
+    "commit-messages / commit-messages"
   ]
   actions_secrets = {
     DOCKERHUB_USERNAME          = data.bitwarden_secret.dockerhub_username.value

--- a/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
+++ b/workspaces/github/repo-homelab-ops-kubernetes-apps.tf
@@ -11,6 +11,22 @@ module "repo_homelab_ops_kubernetes_apps" {
     "jdx/mise-action@*",
     "tj-actions/changed-files@*"
   ]
+  # DO NOT APPLY until ppat/homelab-ops-kubernetes-apps#3416 and #3417 are both fixed
+  # AND confirmed reliably green on that repo's `main` - see PR description for why.
+  #
+  # Only `kubernetes-manifests` is listed: it's a single, fixed-name job with no
+  # matrix, so it always reports a check for every PR. The `diff-changes.yaml`
+  # workflow's `diff` job (the #3417 checks) uses a *dynamic* `module x resource`
+  # matrix derived from which modules a given PR touches - e.g. `diff (infra-database,
+  # helmrelease)` only exists on PRs that touch infra-database. Naming any of those
+  # matrix entries here would make GitHub wait forever ("Expected") on PRs that never
+  # produce that specific combination, permanently blocking their merge. There's no
+  # aggregator/gate job over the diff matrix to point at instead (verified by reading
+  # .github/workflows/diff-changes.yaml directly) - adding one is a separate follow-up
+  # if the diff checks should ever become required.
+  required_status_checks = [
+    "kubernetes-manifests"
+  ]
   actions_secrets = {
     DOCKERHUB_USERNAME          = data.bitwarden_secret.dockerhub_username.value
     DOCKERHUB_TOKEN             = data.bitwarden_secret.dockerhub_token.value


### PR DESCRIPTION
## Status: ready to apply

Both underlying issues are merged and confirmed green on `main`:

| Issue | Fix | State |
|---|---|---|
| ppat/homelab-ops-kubernetes-apps#3416 (`kubernetes-manifests`) | ppat/validate-kubernetes-manifests#100 (released v0.1.11) → ppat/homelab-ops-kubernetes-apps#3516 | **Merged.** Re-verified directly: dispatched `lint.yaml` against `main`'s tip (not just inferred from the merge) — `kubernetes-manifests` passes in full-repo-scan mode. |
| ppat/homelab-ops-kubernetes-apps#3417 (`diff (helmrelease)`/`diff (kustomization)`) | ppat/homelab-ops-kubernetes-apps#3515 | **Merged.** 32/32 diff jobs passed pre-merge; `diff-changes.yaml` has no `workflow_dispatch` trigger so a direct post-merge re-run on `main` wasn't possible the same way — this rests on the PR's own pre-merge verification rather than an identical live re-check. |

`required_status_checks.contexts` was `[]` before this — nothing was required to merge, which is why both issues sat permanently red without ever blocking anything.

## What this adds

```hcl
required_status_checks = [
  "kubernetes-manifests",
  "detect-changes / detect-changed-files",
  "pre-commit / pre-commit"
]
```

## Why these three, and not the rest of `lint.yaml`, and not `diff`

A GitHub Actions job's check-run *name* is only guaranteed stable across every PR if either it has no job-level `if:` at all, or its `if:` is unconditionally true for every `pull_request` event. Two distinct, both-confirmed-against-real-runs ways a job can fail that test:

**1. Workflow-level `paths:` filters + dynamic matrices** (`diff-changes.yaml`'s `diff` job, and every chainsaw `test-*.yaml` workflow). If a PR doesn't touch any matching path, the workflow never triggers — zero check runs posted for any job in it, so a required check on one of those names sits stuck "Expected — Waiting for status to be reported" forever on unrelated PRs. `diff-changes.yaml` compounds this with a *dynamic* `module × resource` matrix since #3515 (confirmed: 32 distinct `diff (<module>, <resource>)` contexts on that PR alone, varying per-PR by what changed) — there's no aggregator/gate job over that matrix to point at instead.

**2. Job-level `if:` gating a *reusable workflow call*** — `lint.yaml`'s `github-actions`, `markdown`, `renovate-config-check`, `shellcheck`, `yaml` jobs, each gated on `fromJSON(needs.detect-changes.outputs.results).<bucket>_any_changed`. This is subtler: the workflow itself always triggers (no path filter), and the job always reports *something* — but the check-run **name itself changes** depending on whether the job actually invoked the reusable workflow. Confirmed via the raw Checks API (not just CLI display) against a real PR's head commit:

```
markdown                        | conclusion=skipped   (bucket didn't change)
renovate-config-check           | conclusion=skipped
shellcheck                      | conclusion=skipped
yaml / yamllint                 | conclusion=success   (bucket did change)
github-actions / github-actions | conclusion=success
```

`shellcheck` and `shellcheck / shellcheck` are two genuinely different context strings to GitHub. Requiring either one leaves it permanently unsatisfied in the other scenario. Classic branch protection has no OR-semantics, so requiring both doesn't help — it'd just permanently wait on whichever one didn't fire that PR. Fixing this needs an always-run gate job in `lint.yaml` (aggregating `needs.*.result` with `if: always()`) before those five can be safely required — a separate `homelab-ops-kubernetes-apps` change, not something this Terraform list alone can solve. Same applies to eventually requiring the `diff` checks.

The three included here are unaffected by either failure mode: `kubernetes-manifests` has no reusable-workflow call at all (inline job, name never has a slash); `detect-changes`/`pre-commit` have no job-level `if:` at all.

**`commit-messages / commit-messages` is also name-stable** (its only gate is `event_name == 'pull_request'`, true for every real PR — it only skips on `workflow_dispatch`/`schedule`, which don't participate in PR merge gating) but deliberately left out anyway, per repo-owner guidance: Renovate-authored commits sometimes fail commitlint, and making this required would block those PRs — including automerge — on a lint failure neither this repo nor Renovate's own config fully controls. Revisit only if that gets fixed at the source (Renovate's commit-message template, or the commitlint config).

## Terraform validation performed

- `terraform fmt -check -diff` — clean.
- `terraform validate` (Terraform 1.6.6 via `mise exec`, matching this workspace's pinned `required_version`) — **succeeded**, only a pre-existing unrelated `bitwarden` provider deprecation warning. Run with dummy provider env vars against the already-initialized `.terraform/` cache; doesn't contact any real API or touch remote state.
- Skipped only the `terraform-validate` *pre-commit hook* specifically (`SKIP=terraform-validate`, not `--no-verify`) — that hook does a full `terraform init` against this workspace's real S3 backend, which is exactly the boundary this change is scoped to respect. All other hooks (fmt, tflint, checkov, secret-detection) ran and passed. This repo's own CI (`terraform-validate`/`terraform-lint`/`terraform-fmt` jobs) also ran and passed against this exact diff.
- No `terraform plan` or `terraform apply` was run.

## Cross-references

- ppat/homelab-ops-kubernetes-apps#3416 (closed) / #3417 (closed)
- ppat/homelab-ops-kubernetes-apps#3515, #3516 — the merged fixes
- ppat/validate-kubernetes-manifests#100 (merged, released v0.1.11) — #3416's actual upstream fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
