### PR TITLE
feat(litellm): add workspace scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ state/backend.
 | [`authentik`](workspaces/authentik) | Authentik SSO — applications, providers, and outposts |
 | [`github`](workspaces/github) | GitHub org repository configuration |
 | [`harbor`](workspaces/harbor) | Harbor container registry — auth, system config, robot accounts |
+| [`litellm`](workspaces/litellm) | LiteLLM proxy — models, remote MCP servers, and virtual keys |
 | [`minio-homelab`](workspaces/minio-homelab) | MinIO instance on homelab infra — Terraform state and Authentik media buckets |
 | [`minio-nas`](workspaces/minio-nas) | MinIO instance on NAS — CloudNativePG and Longhorn backup buckets |
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -49,6 +49,7 @@ module.exports = {
         'authentik',
         'github',
         'harbor',
+        'litellm',
         'minio-homelab',
         'minio-nas',
         // terraform dependencies

--- a/workspaces/litellm/.ci.env
+++ b/workspaces/litellm/.ci.env
@@ -1,0 +1,3 @@
+BWS_ACCESS_TOKEN="dummy"
+LITELLM_API_BASE="dummy"
+LITELLM_API_KEY="dummy"

--- a/workspaces/litellm/.terraform.lock.hcl
+++ b/workspaces/litellm/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/maxlaverse/bitwarden" {
+  version     = "0.17.6"
+  constraints = "0.17.6"
+  hashes = [
+    "h1:Rke+62Qj1g/4rR9HyyoR067z+dfPQaPTAgc7nZby+tI=",
+    "zh:01acd6e3da51973cb1327859ba61282711af92d2efa51bf4613bcdb9a15f2443",
+    "zh:375f1574dd11eca89e4ff9b99739af87b5f04d2cb6e99728c62c32ce24162556",
+    "zh:5b176aa6e86a16010c60b6e4d0e0717b50a3ea0f935f6763f9fe392ec5290fc9",
+    "zh:666548df75a345692b38cb302c1c065e23a535fb4f26b8fd426222d4fc49fff4",
+    "zh:743c1f310a78ef24d5abb39f8fd4fd92989336392a875d4dfa774338c759ec4a",
+    "zh:83c78ca7bbe5daff314823f389517fdba9f596aff5de7af3575dc83ccf908a2a",
+    "zh:8d2b75f76de03f718090e9e491f163e53fc62a6716237dd6dd7f1c428cbc34a3",
+    "zh:af7251eceffa37de97330852d6dece621921a182416e658c3055e398aa76ed4b",
+    "zh:d713b2bbe6973f4d2be015b1d8c3a3b73651924983b05e1b32ffcd2a68b94994",
+    "zh:d7187561fabbc54cc975802863b9b4485f45f0fbd827efe2565e5c471bce2db4",
+    "zh:f46396f560978889fe8bfc4fd28edf024447ef698a42f7d0bdfcb3f857243b49",
+    "zh:f5e72121ea16be4f8211e4be85afefcc437b3aad84473010d142d7fe0d5db181",
+    "zh:f7192bbf5192a79ccafc9ea8bade0be7015b556a90175058d497c36884ab9cc3",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/ncecere/litellm" {
+  version     = "2.0.1"
+  constraints = "2.0.1"
+  hashes = [
+    "h1:RRpGz0n5KZGojsJ5Jwmw79svyCerciZgeX9qYPgUY34=",
+    "zh:0bcd58f49bf0e82114f3fe2c2b9c380320b686b549e3d2850500887f41a5faba",
+    "zh:0bffc334578a09365a4aa4c55ea0b03e3aa93481bbd4a78f61a3d78b546d0065",
+    "zh:14479719686f82081f0b4db13b7512579d9fa256901dc52830d3e700f57b19eb",
+    "zh:297d12dbe25d02c0118668932aeb725e38456f808c904fe7e83c54a7e8cd9cac",
+    "zh:3cc94f775f8161f459601864e2db00ef439aad8b21e417303f87291f61576bd5",
+    "zh:81777dae4c993db90950516b37a2c13c1891bd55c058b87ffdd485cf3a4a40be",
+    "zh:8c1a30eac0062161cd3af2d0826691779031cc7cf2e4e8dd5fe55ec2c58069df",
+    "zh:93c9cafef01d8c0c11cefa31700fb412c4b1e030abf72827e124cc7ecc5acd3c",
+    "zh:ce2bcb5a1ddbdd8b0f85821d5e03fcd9de82c2226a309675ad04cd4366fc1c90",
+    "zh:d419cf0cc33a42950a6b0c1ff0a730014db10b6b50d40da9c5e93966925c7576",
+    "zh:dd805a63cf2f469c19f529f609d49cde1a5c2ceb1194d9e5fe295d10f6bf11e5",
+    "zh:e1e1d5e6c7f94f8ae9c0b0bb95065da023ec772e6f1bd9d75ec57360361243df",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+    "zh:fa83d81b18dbf19f071560816f9a929e7af9f851534c6891d747162b3f4bb9e0",
+  ]
+}

--- a/workspaces/litellm/terraform.tf
+++ b/workspaces/litellm/terraform.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = "1.6.6"
+
+  backend "s3" {
+    bucket                      = "homelab-terraform-state"
+    key                         = "litellm/terraform.tfstate"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    force_path_style            = true
+  }
+  required_providers {
+    bitwarden = {
+      source  = "maxlaverse/bitwarden"
+      version = "0.17.6"
+    }
+    litellm = {
+      source  = "ncecere/litellm"
+      version = "2.0.1"
+    }
+  }
+}
+
+provider "bitwarden" {
+  experimental {
+    embedded_client = true
+  }
+}
+
+provider "litellm" {
+}

--- a/workspaces/litellm/variables.tf
+++ b/workspaces/litellm/variables.tf
@@ -1,0 +1,5 @@
+# tflint-ignore: terraform_unused_declarations
+variable "bitwarden_project_id" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

- Add an empty-but-valid `workspaces/litellm/` scaffold: backend, `required_providers` (`bitwarden` 0.17.6, `ncecere/litellm` 2.0.1), and empty provider blocks — no LiteLLM resources yet.
- Register the workspace in `commitlint.config.js` `scope-enum` and the README workspaces table.

No functional resources are added. This just gets the workspace initializing and passing CI so later PRs (models, remote MCP servers, virtual keys) can build on a green baseline. Tracking issue: #273.

### Provider config pattern

Chose the empty-block/env-var pattern (matches `harbor`/`authentik`, not `minio-nas`'s variable-driven style): the `ncecere/litellm` provider natively supports `LITELLM_API_BASE`/`LITELLM_API_KEY` env vars as a first-class alternative to explicit `api_base`/`api_key` arguments, so an empty `provider "litellm" {}` block plus those two env vars in `.ci.env` is the simplest fit — no new variables needed beyond `bitwarden_project_id` (kept for the future secret-writeback PR, currently unused so tagged `# tflint-ignore: terraform_unused_declarations`, matching existing precedent in `workspaces/authentik/external-resources.tf`).

## Test plan

- [x] `terraform init` (via `-backend=false`, since this sandbox has no real backend AWS credentials — provider install succeeded and generated `.terraform.lock.hcl`)
- [x] `terraform validate` (with `.ci.env` sourced) — success
- [x] `terraform fmt -check -recursive` from repo root — clean
- [x] `tflint --config=.tflint.hcl` — clean (after adding the `tflint-ignore` comment)
- [x] `checkov --config-file .checkov.yaml -d .` from repo root — 16 passed, 0 failed
- [x] `pre-commit run --all-files` — all hooks pass on this workspace's files (large-scale `--all-files` run also hits a pre-existing "Missing region value" gap on the *other* workspaces in this sandbox, unrelated to this change — no real AWS backend creds/region available here)