### PR TITLE
fix(litellm-virtual-key): stop metadata/note defaults from drifting imported keys

### DIFF
--- a/modules/litellm-virtual-key/bitwarden.tf
+++ b/modules/litellm-virtual-key/bitwarden.tf
@@ -7,5 +7,8 @@ resource "bitwarden_secret" "apikey" {
   key        = "apikey_litellm_${replace(var.consumer, "/[^a-zA-Z0-9]/", "")}"
   value      = litellm_key.this.key
   project_id = var.bitwarden_project_id
-  note       = "LiteLLM virtual key (sk-...) for ${var.consumer}"
+  # Empty by default, not a descriptive template — see the comment on var.note for why a
+  # non-empty default was a permanent diff against the five adopted secrets, all of which
+  # already have an empty note live.
+  note = var.note
 }

--- a/modules/litellm-virtual-key/key.tf
+++ b/modules/litellm-virtual-key/key.tf
@@ -26,6 +26,19 @@ locals {
   # So `[]` is the API's rendering of "no restriction", but `null` is the one Terraform
   # config value that reproduces "this key's models field has never been touched" without
   # asserting a value the live key doesn't actually have set.
+  #
+  # CAVEAT DISCOVERED DURING THE FIRST REAL IMPORT (2026-08-11, openwebui): this measurement
+  # only proves `models = null` plans clean in ISOLATION, against a bare resource with nothing
+  # else set. It does NOT by itself guarantee the whole `litellm_key.this` resource plans
+  # clean — if ANY other attribute has a genuine diff against the freshly-imported (mostly
+  # null) state, terraform-plugin-framework's default handling for Computed attributes with no
+  # `UseStateForUnknown` plan modifier (none of litellm_key's have one, except id/key/key_alias)
+  # marks EVERY other unconfigured Computed attribute — including `models`, even though it
+  # genuinely matches state — as `(known after apply)`. This actually happened: the module's
+  # old `metadata` default (`{}`, a known non-null empty map) differed from the imported key's
+  # `metadata = null` state and was enough to trigger the cascade on its own. See the comment
+  # on `var.metadata` in variables.tf for the full measurement. Moral: a clean plan requires
+  # EVERY attribute set in config to match live state exactly, not just `models`.
   resolved_models = var.unrestricted_models ? null : var.models
 }
 

--- a/modules/litellm-virtual-key/variables.tf
+++ b/modules/litellm-virtual-key/variables.tf
@@ -133,9 +133,51 @@ variable "blocked" {
 }
 
 variable "metadata" {
-  description = "Metadata attached to the key. Values are strings, but the provider (metadata_helpers.go: convertMetadataToNative) treats any value starting with '[' or '{' as JSON and parses it back to a native type before sending to the API — so a live value that's an object or array (e.g. LiteLLM's own tag_rpm_limit: {}) must be given here as jsonencode(...), not a bare string, to round-trip correctly. jsonencode(false)/jsonencode(true) work the same way for booleans (e.g. throttle_on_budget_exceeded)."
+  # DEFAULT MUST BE `null`, NOT `{}` — measured against the sandbox (namespace litellm-audit,
+  # kube context sandbox-talos, real ncecere/litellm 2.0.1 provider), 2026-08-11, reproducing
+  # the openwebui production import verbatim:
+  #
+  #   `terraform import` never populates litellm_key's Optional+Computed attributes beyond
+  #   id/key (ImportState only sets those two — resource_key.go:397-403); the subsequent Read
+  #   leaves every other attribute at its zero value (null) unless the live key already has a
+  #   non-empty value for it (readKey's `else if !data.X.IsNull()` reset-to-empty branches never
+  #   fire on a freshly-imported, still-null field — resource_key.go:805-1028). So a key whose
+  #   live metadata is the (API-rendered) empty object `{}` lands in state as `metadata = null`,
+  #   not `metadata = {}` — same "omitted vs. explicit-empty are indistinguishable after the
+  #   fact" ambiguity as the `models` footgun below, and resolved the same way: `null` is the
+  #   config value that reproduces "never touched," `{}` is a real, different value.
+  #
+  #   None of litellm_key's Optional+Computed attributes carry a `UseStateForUnknown` plan
+  #   modifier (checked against the provider's schema.go — only `id`, `key`, and `key_alias`
+  #   do). terraform-plugin-framework's default behavior for a Computed attribute with no
+  #   config value is to plan it as Unknown, but ONLY once the resource is undergoing an update
+  #   at all — a config that introduces zero genuine diff against imported (mostly-null) state
+  #   plans clean with nothing marked unknown. `metadata = {}` here (a known, non-null empty
+  #   map) is itself exactly such a genuine diff against the imported `null` state — and that
+  #   one spurious diff was enough to flip the ENTIRE resource into "update" mode, cascading
+  #   `(known after apply)` onto every other untouched attribute (models, tpm_limit, rpm_limit,
+  #   max_budget, aliases, config, permissions, guardrails, prompts, tags, blocked, ...) even
+  #   though none of them were actually changing. Reproduced exactly (byte-for-byte identical
+  #   plan output shape to the production incident) with `metadata = {}`; switching this default
+  #   to `null` produced a genuine "No changes" plan directly after import, no apply needed.
+  #
+  #   Apply was ALSO verified safe despite the `(known after apply)` noise, independently of
+  #   this fix: buildKeyRequest (resource_key.go:478-684) guards every field with
+  #   `!data.X.IsUnknown()` before including it in the POST /key/update body, so Unknown fields
+  #   are simply omitted from the wire request rather than sent as null/empty — and LiteLLM's
+  #   /key/update treats an omitted field as "leave unchanged" (confirmed via GET /key/info
+  #   diffed before/after: only the one deliberately-configured field changed, nothing else was
+  #   reset). But "safe" isn't the same as "not a permanent diff", which this default fixes.
+  #
+  # A future consumer that genuinely needs metadata (openclaw/n8n today) still sets this to a
+  # real non-null map, transcribed verbatim from `GET /key/info` — see key-openclaw.tf/
+  # key-n8n.tf. Empty stays the correct default for a newly-created sixth consumer too: it's
+  # what a fresh `litellm_key` with no metadata argument reads back as, so there's nothing
+  # inconsistent about a new key defaulting to the same "untouched" representation as the five
+  # adopted ones.
+  description = "Metadata attached to the key. Values are strings, but the provider (metadata_helpers.go: convertMetadataToNative) treats any value starting with '[' or '{' as JSON and parses it back to a native type before sending to the API — so a live value that's an object or array (e.g. LiteLLM's own tag_rpm_limit: {}) must be given here as jsonencode(...), not a bare string, to round-trip correctly. jsonencode(false)/jsonencode(true) work the same way for booleans (e.g. throttle_on_budget_exceeded). Defaults to null, not {} — see the comment above for why an explicit empty map is a real (if trivial) diff against a freshly-imported key's state, not a no-op."
   type        = map(string)
-  default     = {}
+  default     = null
 }
 
 variable "tags" {
@@ -154,6 +196,30 @@ variable "bitwarden_project_id" {
   description = "Bitwarden Secrets project under which to save this key's plaintext token"
   type        = string
   sensitive   = true
+}
+
+variable "note" {
+  # DEFAULT MUST BE "", NOT A DESCRIPTIVE TEMPLATE STRING — unlike litellm_key's
+  # Optional+Computed attributes above, bitwarden_secret's `note` is schema-REQUIRED
+  # (`terraform providers schema -json`: `"note": {"required": true, "type": "string"}`, no
+  # `computed` key at all), so it can never be left null/omitted — every apply, import
+  # included, must send some string. The five secrets this module adopts already exist with an
+  # empty note (confirmed via `bws secret list` against the real Bitwarden project, 2026-08-10:
+  # every `apikey_litellm_*` entry's note is ""), so an explicit descriptive default here — the
+  # module used to hardcode "LiteLLM virtual key (sk-...) for ${var.consumer}" — is a real,
+  # permanent diff against every one of them post-import, same failure shape as the
+  # metadata/models defaults above but on a required rather than a computed attribute (so it
+  # shows as a genuine `~ note = "" -> "..."` in-place update every single plan, not a
+  # transient known-after-apply cascade). The owner's standing instruction is to reproduce live
+  # state, not improve on it, so the default is empty to match.
+  #
+  # A newly-created sixth consumer reads back the same way: a fresh bitwarden_secret with no
+  # note argument stores "" too, so defaulting to empty here isn't an inconsistency between
+  # adopted and newly-created keys — it's the same "untouched" representation either way. A
+  # caller who wants a descriptive note on a new key can still pass one explicitly.
+  description = "Note attached to the Bitwarden secret. Required by the bitwarden_secret resource schema (unlike litellm_key's attributes, this cannot be left null), so it always needs a value — defaults to empty to match the five keys imported from hand-minted Bitwarden secrets (confirmed via bws secret list). Pass an explicit string for a new consumer that wants a descriptive note; empty remains a valid, consistent choice there too."
+  type        = string
+  default     = ""
 }
 
 # --- object_permission REST seam inputs (see object-permission.tf) ---


### PR DESCRIPTION
## Summary

The first real import (openwebui, adopted into `workspaces/litellm/`) showed
`terraform plan -target=module.openwebui` reporting `0 to add, 2 to change,
0 to destroy` instead of the designed no-op. This PR fixes the two root
causes, both measured empirically on the sandbox (namespace `litellm-audit`,
kube context `sandbox-talos`) rather than assumed — see the code comments in
`modules/litellm-virtual-key/{key,variables}.tf` for the full measurement.

### A. `bitwarden_secret.note` — spurious diff on all 5 secrets

`note` is schema-**Required** on `bitwarden_secret` (not Optional/Computed —
confirmed via `terraform providers schema -json`), so it can never be left
null. The module hardcoded a descriptive per-consumer string as its value;
the five live secrets it adopts all have an **empty** note (confirmed via
`bws secret list`), so that hardcoded default was a permanent diff on every
one of them, forever.

**Fix**: `note` is now a variable defaulting to `""`, matching live. A new
sixth consumer can still pass an explicit note if wanted; empty remains a
consistent default there too (a freshly-created secret with no note argument
reads back the same way).

### B. `litellm_key.this` — every Optional+Computed attribute `(known after apply)`

Reproduced byte-for-byte against the sandbox: created a key via the raw API
the same way the owner's five hand-minted keys exist (no `models`, no
`object_permission`), imported it into the exact shape `key-openwebui.tf`
uses, and planned.

- `terraform import` only ever sets `id`/`key` (`ImportState` in the
  provider's `resource_key.go`); every other attribute stays `null` in state
  unless the live key already has a non-empty value for it.
- None of `litellm_key`'s Optional+Computed attributes carry a
  `UseStateForUnknown` plan modifier (only `id`/`key`/`key_alias` do). Once
  **any** attribute has a genuine diff against that mostly-null imported
  state, terraform-plugin-framework's default behavior marks every *other*
  unconfigured attribute Unknown too — even ones that already match state.
- The module's own `metadata = {}` default (a known, non-null empty map)
  was exactly such a diff against the live key's genuinely-untouched
  `metadata = null` state, and was sufficient on its own to trigger the
  entire cascade (verified by isolating it: `metadata = {}` alone, nothing
  else, reproduces the full storm; `metadata = null` alone plans clean).

**Is `apply` safe despite the noise?** Yes — verified by diffing `GET
/key/info` before and after an actual apply on the sandbox key: only the
one deliberately-configured field (`allowed_routes`) changed, plus
`updated_at`. Nothing else (`models`, `metadata`, `spend`, `expires`,
`blocked`, budget) was reset or altered. This is because `buildKeyRequest`
omits any attribute that's Unknown from the `POST /key/update` body
entirely, and LiteLLM's endpoint treats an omitted field as "leave
unchanged" (partial-update semantics), not "reset to default."

**Does it converge?** Yes, but only *after* one such apply — the same
Unknown-resolution logic in the provider's `readKey()` repopulates
previously-null fields as concrete empty collections (`[]`/`{}`) once
resolved, and from then on Terraform carries those forward cleanly. So this
was a one-time (if unsettling) transition, not permanent churn — still not
something to leave in place given the fix is one line.

**Fix**: `metadata` now defaults to `null` instead of `{}`. Re-tested end to
end: import a fresh sandbox key (with `allowed_routes` pre-set, matching how
the live openwebui key already carries it) into the corrected shape → clean
`terraform plan` immediately after import, no apply required, no unknowns.

### Scope

No `workspaces/litellm/key-*.tf` files needed changes: none of the five set
`metadata` or `note` explicitly, so all five pick up the corrected defaults.
`openclaw`/`n8n`'s explicit non-null `metadata` (transcribed from live
`GET /key/info`) already matches their real values and is unaffected.

### Also noted, not fixed here (repo-wide, out of scope)

`provider "bitwarden" { experimental { embedded_client = true } }` warns
deprecated in favor of `client_implementation = "embedded"`. Every workspace
in this repo uses the old form — a repo-wide follow-up, not specific to this
module.

## Test plan

- [x] `terraform fmt -check -recursive` (repo root) — clean
- [x] `terraform validate` — module and workspace (workspace validated from
      a throwaway copy with a local backend, since the real
      `workspaces/litellm/.terraform` is already pointed at the production
      S3 backend and was never touched by this change)
- [x] `tflint --config=.tflint.hcl` — module and workspace, clean
- [x] `checkov --config-file .checkov.yaml -d .` — module, clean
- [x] `pre-commit run --all-files` (on the actual commit) — all hooks passed
- [x] Empirically reproduced the production incident on the sandbox
      (`litellm-audit` / `sandbox-talos`), verified the fix eliminates it,
      verified `apply` was safe via `GET /key/info` before/after diff, and
      verified the plan converges — never touched the homelab proxy or
      production backend
- [ ] CI (pending — will poll to terminal)