### PR TITLE
feat(garage-homelab): provision Garage buckets in Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ state/backend.
 | Name | Description |
 |------|-------------|
 | [`authentik`](workspaces/authentik) | Authentik SSO — applications, providers, and outposts |
+| [`garage-homelab`](workspaces/garage-homelab) | Garage instance on homelab infra — Loki, Authentik media, and Terraform state buckets |
 | [`github`](workspaces/github) | GitHub org repository configuration |
 | [`harbor`](workspaces/harbor) | Harbor container registry — auth, system config, robot accounts |
 | [`litellm`](workspaces/litellm) | LiteLLM proxy — models, remote MCP servers, and virtual keys |
@@ -32,6 +33,7 @@ paths.
 |------|-------------|
 | [`authentik-oauth2-application`](modules/authentik-oauth2-application) | Authentik OAuth2 provider + application + group binding |
 | [`authentik-proxy-application`](modules/authentik-proxy-application) | Authentik proxy provider + application + group binding |
+| [`garage-bucket`](modules/garage-bucket) | Garage bucket with key, permissions, and lifecycle rules |
 | [`github-repository`](modules/github-repository) | GitHub repository, branch protection, actions, environments |
 | [`harbor-local-registry`](modules/harbor-local-registry) | Harbor local (push) registry with retention policy |
 | [`harbor-proxy-registry`](modules/harbor-proxy-registry) | Harbor pull-through proxy registry with retention policy |

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -41,6 +41,7 @@ module.exports = {
         // modules
         'authentik-oauth2-application',
         'authentik-proxy-application',
+        'garage-bucket',
         'github-repository',
         'harbor-local-registry',
         'harbor-proxy-registry',
@@ -50,6 +51,7 @@ module.exports = {
         'minio-bucket',
         // workspaces
         'authentik',
+        'garage-homelab',
         'github',
         'harbor',
         'litellm',

--- a/modules/garage-bucket/alias.tf
+++ b/modules/garage-bucket/alias.tf
@@ -1,0 +1,73 @@
+# ============================================================================
+# SEAM -- second bucket alias (for public web access) via direct REST call.
+# DELETE THIS FILE WHOLESALE once jkossis/garage's garage_bucket resource
+# supports more than one global_alias (or a dedicated alias resource is added).
+# ============================================================================
+#
+# The gap: jkossis/garage v1.0.5's garage_bucket resource manages exactly one
+# global_alias (checked the schema in internal/provider/bucket_resource.go --
+# Required, RequiresReplace, a single string; no repeated-block or list
+# variant). Garage's Admin API itself supports a bucket having multiple global
+# aliases via POST /v2/AddBucketAlias / RemoveBucketAlias (confirmed against
+# the OpenAPI v2 spec's BucketAliasEnum schema: {bucketId, globalAlias}). The
+# provider's own internal/client/client.go even has an AddBucketAlias Go
+# function that calls this endpoint, but it is unused dead code -- no exposed
+# resource calls it, and its request body shape ({id, alias}) does not match
+# the real API schema ({bucketId, globalAlias}); do not copy it.
+#
+# Why a second alias at all: this bucket's real name (var.bucket_name) is what
+# every consumer and the Bitwarden secret keys in bitwarden.tf are keyed on.
+# Garage's [s3_web] website endpoint resolves which bucket to serve purely
+# from the Host header matching one of the bucket's global aliases -- and this
+# estate's garage module
+# (infrastructure/subsystems/storage-core/garage in homelab-ops-kubernetes-apps)
+# only backs one such hostname today, so this bucket must ALSO carry that
+# literal hostname as an alias to be reachable through it. Consequence: only
+# one bucket across the whole Garage instance can set anonymous_read_hostname
+# at a time, since they'd all need the identical alias value. That's a
+# deliberate, current choice in the apps-repo module's own config, not a
+# property of this seam or of Terraform, and not a Garage constraint either --
+# see ppat/homelab-ops-kubernetes-apps#3652 for what produces it and what
+# lifting it would take.
+#
+# That one-at-a-time constraint IS enforced -- but only at apply time, not
+# plan time, and by Garage itself rather than by Terraform: POST
+# /v2/AddBucketAlias rejects a second bucket claiming an alias already
+# pointed at a different bucket with a 400 ("Alias ... already exists and
+# points to different bucket: ...") -- confirmed against Garage v2.3.0's own
+# source, src/model/helper/locked.rs's set_global_bucket_alias. So a second
+# module call misconfigured with the same anonymous_read_hostname fails loud
+# on `terraform apply`, it does not silently steal the alias from the first
+# bucket -- but nothing here surfaces that at `terraform plan`.
+resource "terracurl_request" "bucket_web_alias" {
+  count = var.anonymous_read_hostname != null ? 1 : 0
+
+  name   = "garage-bucket-${var.bucket_name}-web-alias"
+  method = "POST"
+  url    = "${trimsuffix(var.garage_admin_endpoint, "/")}/v2/AddBucketAlias"
+
+  headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "Bearer ${var.garage_admin_token}"
+  }
+
+  request_body = jsonencode({
+    bucketId    = garage_bucket.bucket.id
+    globalAlias = var.anonymous_read_hostname
+  })
+
+  response_codes = ["200"]
+  skip_read      = true
+
+  destroy_method = "POST"
+  destroy_url    = "${trimsuffix(var.garage_admin_endpoint, "/")}/v2/RemoveBucketAlias"
+  destroy_headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "Bearer ${var.garage_admin_token}"
+  }
+  destroy_request_body = jsonencode({
+    bucketId    = garage_bucket.bucket.id
+    globalAlias = var.anonymous_read_hostname
+  })
+  destroy_response_codes = ["200"]
+}

--- a/modules/garage-bucket/bitwarden.tf
+++ b/modules/garage-bucket/bitwarden.tf
@@ -1,0 +1,13 @@
+resource "bitwarden_secret" "bucket_owner_accesskey" {
+  key        = "bucket_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_accesskey"
+  value      = garage_key.owner.id
+  project_id = var.bitwarden_project_id
+  note       = "${var.bucket_name} bucket's accesskey"
+}
+
+resource "bitwarden_secret" "bucket_owner_secretkey" {
+  key        = "bucket_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_secretkey"
+  value      = garage_key.owner.secret_access_key
+  project_id = var.bitwarden_project_id
+  note       = "${var.bucket_name} bucket's secretkey"
+}

--- a/modules/garage-bucket/bucket.tf
+++ b/modules/garage-bucket/bucket.tf
@@ -1,0 +1,9 @@
+resource "garage_bucket" "bucket" {
+  global_alias = var.bucket_name
+
+  # Garage has no S3 bucket-policy support, so anonymous public read only exists
+  # via this website config -- see var.anonymous_read_hostname's description for
+  # the alias half of making a bucket actually reachable through it.
+  website_enabled        = var.anonymous_read_hostname != null
+  website_index_document = var.anonymous_read_hostname != null ? "index.html" : null
+}

--- a/modules/garage-bucket/key.tf
+++ b/modules/garage-bucket/key.tf
@@ -1,0 +1,16 @@
+resource "garage_key" "owner" {
+  name = var.owner_key_name
+}
+
+# read+write only, never owner: owner additionally grants control over the
+# bucket itself (enable/disable website access, delete the bucket -- see
+# Garage's src/model/permission.rs BucketKeyPerm), which is this module's own
+# responsibility via the admin token, not something a per-service credential
+# should hold. This is the Garage-native equivalent of minio-bucket's default
+# owner_policy (object read/write/delete/list, no bucket administration).
+resource "garage_bucket_permission" "owner" {
+  bucket_id     = garage_bucket.bucket.id
+  access_key_id = garage_key.owner.id
+  read          = true
+  write         = true
+}

--- a/modules/garage-bucket/lifecycle.tf
+++ b/modules/garage-bucket/lifecycle.tf
@@ -1,0 +1,72 @@
+# ============================================================================
+# SEAM -- bucket lifecycle/expiration rules via direct REST call. DELETE THIS
+# FILE WHOLESALE once jkossis/garage exposes lifecycle rules on garage_bucket
+# (or an equivalent resource) natively.
+# ============================================================================
+#
+# The gap: jkossis/garage v1.0.5's garage_bucket resource has no lifecycle
+# argument (checked the provider's own source: internal/provider/bucket_resource.go
+# only wires up global_alias/website_*/max_size/max_objects, and
+# internal/client/client.go's UpdateBucketRequest struct has no lifecycleRules
+# field). Garage's Admin API itself supports it fully and natively on the SAME
+# endpoint the provider already calls for website/quota updates: POST
+# /v2/UpdateBucket accepts a `lifecycleRules` array (confirmed against Garage
+# v2.3.0's own source, src/api/admin/bucket.rs and
+# src/api/common/xml/lifecycle.rs -- field names below are PascalCase XML tag
+# names carried into the JSON body, because Garage's lifecycle config type is
+# shared between the XML-based S3 API and the JSON admin API).
+#
+# This is a more reliable bridge than either competing provider's own lifecycle
+# support: both Arsolitt/garagehq and d0ugal/garage implement it by PUTting
+# S3-style lifecycle XML to `{bucket}?lifecycle` on the S3 port (3900) using the
+# ADMIN bearer token as that request's Authorization header -- but Garage's S3
+# API expects SigV4-signed requests, not bearer tokens, so that path looks
+# likely to fail at apply time. This seam instead calls the real,
+# natively-lifecycle-aware admin endpoint with the same bearer auth every other
+# call in this module already uses successfully.
+resource "terracurl_request" "bucket_lifecycle" {
+  count = var.object_expiration_days != null ? 1 : 0
+
+  name   = "garage-bucket-${var.bucket_name}-lifecycle"
+  method = "POST"
+  url    = "${trimsuffix(var.garage_admin_endpoint, "/")}/v2/UpdateBucket?id=${garage_bucket.bucket.id}"
+
+  headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "Bearer ${var.garage_admin_token}"
+  }
+
+  request_body = jsonencode({
+    lifecycleRules = [
+      {
+        ID         = "expire-after-${var.object_expiration_days}-days"
+        Status     = "Enabled"
+        Expiration = { Days = var.object_expiration_days }
+      }
+    ]
+  })
+
+  response_codes = ["200"]
+
+  # No read-based drift detection: the only source of truth this module
+  # recognizes is its own config, same rationale as
+  # modules/litellm-virtual-key/object-permission.tf.
+  skip_read = true
+
+  # A changed object_expiration_days replaces this resource (terracurl has no
+  # in-place update -- changing request_body forces a destroy-then-create).
+  # destroy_* below issues the clearing call FIRST, then create re-issues the
+  # new value; both hit the same idempotent endpoint, so this is the correct
+  # reconciliation, not a hazard.
+  destroy_method = "POST"
+  destroy_url    = "${trimsuffix(var.garage_admin_endpoint, "/")}/v2/UpdateBucket?id=${garage_bucket.bucket.id}"
+  destroy_headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "Bearer ${var.garage_admin_token}"
+  }
+  # An empty lifecycleRules array is what Garage's own handler treats as
+  # "remove the lifecycle config entirely" (src/api/admin/bucket.rs:
+  # `if lr.is_empty() { None }`) -- a real removal, not a no-op placeholder.
+  destroy_request_body   = jsonencode({ lifecycleRules = [] })
+  destroy_response_codes = ["200"]
+}

--- a/modules/garage-bucket/outputs.tf
+++ b/modules/garage-bucket/outputs.tf
@@ -1,0 +1,10 @@
+output "bucket" {
+  description = "Created bucket"
+  value       = garage_bucket.bucket
+}
+
+output "owner_key" {
+  description = "Created access key"
+  value       = garage_key.owner
+  sensitive   = true
+}

--- a/modules/garage-bucket/terraform.tf
+++ b/modules/garage-bucket/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    bitwarden = {
+      source  = "maxlaverse/bitwarden"
+      version = ">= 0.13"
+    }
+    garage = {
+      source  = "jkossis/garage"
+      version = ">= 1.0"
+    }
+    # Generic REST client used only by the bucket-lifecycle and web-alias seams
+    # (lifecycle.tf, alias.tf) -- see the comment at the top of each for why.
+    terracurl = {
+      source  = "devops-rob/terracurl"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/modules/garage-bucket/variables.tf
+++ b/modules/garage-bucket/variables.tf
@@ -1,0 +1,59 @@
+variable "bitwarden_project_id" {
+  description = "Bitwarden Secrets project under which to save the owner key's access and secret keys"
+  type        = string
+  sensitive   = true
+}
+
+variable "bucket_name" {
+  description = "Name of the Garage bucket to create (its global alias)"
+  type        = string
+}
+
+variable "owner_key_name" {
+  description = "Human-friendly name for the Garage access key that owns this bucket"
+  type        = string
+}
+
+variable "object_expiration_days" {
+  description = "Number of days after which objects expire. If null, no expiration rule is applied. Implemented via a REST seam, not the garage provider itself -- see lifecycle.tf."
+  type        = number
+  default     = null
+}
+
+variable "anonymous_read_hostname" {
+  description = <<-EOT
+    When set, enables anonymous public read for this bucket via Garage's [s3_web]
+    website endpoint (Garage has no S3 bucket-policy support, unlike MinIO -- this
+    is the only mechanism it offers) and adds this value as a SECOND global alias
+    on the bucket, alongside bucket_name -- implemented via a REST seam, not the
+    garage provider itself, see alias.tf for why. Must exactly match the Host
+    header Garage's web endpoint will actually receive for this bucket to be
+    reachable: in this estate that's the storage-core module's own web Ingress
+    host (garage-web.$${domain_name}).
+
+    At most one bucket across the whole Garage instance can use this at a time --
+    a deliberate, current choice in the apps-repo module's own [s3_web]/Ingress
+    configuration, not a property of this variable, this module, or Terraform,
+    and not a Garage constraint either. It's liftable: see
+    ppat/homelab-ops-kubernetes-apps#3652 for what produces the limit today and
+    what changing it would take. Don't look for the fix here.
+
+    Null (the default) disables website access entirely, the only valid value for
+    every bucket that doesn't need public reads.
+  EOT
+  type        = string
+  default     = null
+}
+
+# --- REST seam inputs (lifecycle.tf, alias.tf) ---
+
+variable "garage_admin_endpoint" {
+  description = "Base URL of the Garage Admin API (e.g. http://localhost:3903 via a kubectl port-forward -- see the workspace's terraform.tf for why), used only by the lifecycle/web-alias REST seams. The garage provider itself gets this from the GARAGE_ENDPOINT env var; terracurl has no such implicit config and needs it passed explicitly."
+  type        = string
+}
+
+variable "garage_admin_token" {
+  description = "Garage admin API bearer token, used only by the lifecycle/web-alias REST seams to authenticate their direct admin API calls. The garage provider itself gets this from the GARAGE_TOKEN env var."
+  type        = string
+  sensitive   = true
+}

--- a/workspaces/garage-homelab/.ci.env
+++ b/workspaces/garage-homelab/.ci.env
@@ -1,0 +1,3 @@
+BWS_ACCESS_TOKEN="dummy"
+GARAGE_ENDPOINT="http://dummy:3903"
+GARAGE_TOKEN="dummy"

--- a/workspaces/garage-homelab/.terraform.lock.hcl
+++ b/workspaces/garage-homelab/.terraform.lock.hcl
@@ -1,0 +1,68 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/devops-rob/terracurl" {
+  version     = "2.11.0"
+  constraints = ">= 2.0.0, 2.11.0"
+  hashes = [
+    "h1:y+qSMDxz3kBa4En+wrmVoG4tCFBDvtLgM3TtwpEEskA=",
+    "zh:14c958b8646905eccf57ac8247ecbb79511b2ad08bedbeceee719b68b8b984a7",
+    "zh:2effadc4cc087991e2b2df6bb559a2df9ea5221fe19cb882da83f87ae107a48d",
+    "zh:3a296eea81014c97f23a719e6c7d9b11e21ca17cac36117c4384722487d0bda8",
+    "zh:3be03e4bc1fb609cd14a8ef3514d023f9ba88687a22bd5ac67e0ff8c69c7af91",
+    "zh:44a4b7e20729509dfb175a852bb18e6db3d407bda00f14b59983f96e22ab0470",
+    "zh:4bc1b2464ef8ce75263cccd6656fcf1db7aaf548035b041bb94c7f6ebf91a5f5",
+    "zh:66f6c6ba0ff0ab20a36419bcaa3228c8ccdd736b11600f242a20fd3465d5ca58",
+    "zh:7a89202216a1778f524b66b981eaff711884e75bee5cc871648c4b58db5c3819",
+    "zh:8602feb759fd91a05f71b24a012440963d8d27e4616ff83f7f19a9b1b7c0f49b",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:9396748181cfe7b42f598c5af8f06b8360cc688f4ee91caf35700de0bf3baabf",
+    "zh:9d6b0bf736f6920f0928370d2fbe513cde5698bbe4bd002e132f58662daa59d9",
+    "zh:b38d74d6048ed26394a07fed2bf692f29122ac30b4eceaf51a339cb169b6535a",
+    "zh:fc178f3ae700fff71d14a58a1c66919872e4dfb74e69d895c54545f48cdb9737",
+  ]
+}
+
+provider "registry.terraform.io/jkossis/garage" {
+  version     = "1.0.5"
+  constraints = ">= 1.0.0, 1.0.5"
+  hashes = [
+    "h1:89iUT/l7xE/8vzIPbz2axzNZfZQoVShmQvxfmDdQGjg=",
+    "zh:16f3198cd97ced926da49bca8e986ea07f1f9d15544d4a89ca4c5b9cdea79ead",
+    "zh:18684202936e98251731b1b35c92284999a22cf673eb175316f87a1397bb4842",
+    "zh:270c5e4ea0e15655ad39a49be7c33e36da48063ef1ad50dc24e99be4fdeff5a2",
+    "zh:6e86bab6209fa420cc04cf6ed668ff4ca36baa4a6147bf18aa0d71d3ebce80fc",
+    "zh:85feae7727751d760fac202c242c6086486be8dd4af2e9c41606e4c42359fd92",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8a55eea649bd04139e3e696230e959a3485281415d423e0f854c344a435e4179",
+    "zh:91b9a0e8ee379ea6de077c74b2458507e50e47f8b4a6b14460560a15b8f60b47",
+    "zh:943b6435aef49cbc1beabe83675cb14e2224c054a62444d8a830dea070df3102",
+    "zh:9cd7e7ed9fb1a1e915681c01421f6a59db4a2d3f0e4b0d2b9c6be9b495043c7e",
+    "zh:c0123c8242c81ab63ce2a168a7d4940da34f08033f9457395fd1c4bd370eeab9",
+    "zh:c07f7bc3f65a2dfb90f61d5e9e9c0576a5cd9d4f572f463484b0b4076c31b44d",
+    "zh:c2e804636f19fe3db226c2f5b1131735d8a4b43d36c7577798f94304cefb203a",
+    "zh:e9dbe0e229b5f3e3c88416e179f14dee6a3eb7c8407c4d8f6a474e09e90f259f",
+  ]
+}
+
+provider "registry.terraform.io/maxlaverse/bitwarden" {
+  version     = "0.17.6"
+  constraints = ">= 0.13.0, 0.17.6"
+  hashes = [
+    "h1:Rke+62Qj1g/4rR9HyyoR067z+dfPQaPTAgc7nZby+tI=",
+    "zh:01acd6e3da51973cb1327859ba61282711af92d2efa51bf4613bcdb9a15f2443",
+    "zh:375f1574dd11eca89e4ff9b99739af87b5f04d2cb6e99728c62c32ce24162556",
+    "zh:5b176aa6e86a16010c60b6e4d0e0717b50a3ea0f935f6763f9fe392ec5290fc9",
+    "zh:666548df75a345692b38cb302c1c065e23a535fb4f26b8fd426222d4fc49fff4",
+    "zh:743c1f310a78ef24d5abb39f8fd4fd92989336392a875d4dfa774338c759ec4a",
+    "zh:83c78ca7bbe5daff314823f389517fdba9f596aff5de7af3575dc83ccf908a2a",
+    "zh:8d2b75f76de03f718090e9e491f163e53fc62a6716237dd6dd7f1c428cbc34a3",
+    "zh:af7251eceffa37de97330852d6dece621921a182416e658c3055e398aa76ed4b",
+    "zh:d713b2bbe6973f4d2be015b1d8c3a3b73651924983b05e1b32ffcd2a68b94994",
+    "zh:d7187561fabbc54cc975802863b9b4485f45f0fbd827efe2565e5c471bce2db4",
+    "zh:f46396f560978889fe8bfc4fd28edf024447ef698a42f7d0bdfcb3f857243b49",
+    "zh:f5e72121ea16be4f8211e4be85afefcc437b3aad84473010d142d7fe0d5db181",
+    "zh:f7192bbf5192a79ccafc9ea8bade0be7015b556a90175058d497c36884ab9cc3",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/workspaces/garage-homelab/bucket-authentik-media.tf
+++ b/workspaces/garage-homelab/bucket-authentik-media.tf
@@ -1,0 +1,10 @@
+module "authentik_media" {
+  source = "../../modules/garage-bucket"
+
+  bucket_name             = "${local.bucket_prefix}-authentik-media"
+  owner_key_name          = "authentik"
+  anonymous_read_hostname = var.garage_web_hostname
+  bitwarden_project_id    = var.bitwarden_project_id
+  garage_admin_endpoint   = var.garage_admin_endpoint
+  garage_admin_token      = var.garage_admin_token
+}

--- a/workspaces/garage-homelab/bucket-loki-chunks.tf
+++ b/workspaces/garage-homelab/bucket-loki-chunks.tf
@@ -1,0 +1,15 @@
+# No object_expiration_days here: Loki's chunk retention is presumably enforced
+# by Loki's own compactor (retention_period in its config), not S3/Garage
+# lifecycle rules -- this workspace doesn't have visibility into that config to
+# assert a matching number, and the MinIO original of this bucket was never
+# under Terraform either (nothing to mirror). Revisit if Loki's compactor
+# retention ever needs a bucket-side backstop.
+module "loki_chunks" {
+  source = "../../modules/garage-bucket"
+
+  bucket_name           = "${local.bucket_prefix}-loki-chunks"
+  owner_key_name        = "loki"
+  bitwarden_project_id  = var.bitwarden_project_id
+  garage_admin_endpoint = var.garage_admin_endpoint
+  garage_admin_token    = var.garage_admin_token
+}

--- a/workspaces/garage-homelab/bucket-loki-ruler.tf
+++ b/workspaces/garage-homelab/bucket-loki-ruler.tf
@@ -1,0 +1,9 @@
+module "loki_ruler" {
+  source = "../../modules/garage-bucket"
+
+  bucket_name           = "${local.bucket_prefix}-loki-ruler"
+  owner_key_name        = "loki"
+  bitwarden_project_id  = var.bitwarden_project_id
+  garage_admin_endpoint = var.garage_admin_endpoint
+  garage_admin_token    = var.garage_admin_token
+}

--- a/workspaces/garage-homelab/bucket-terraform-state.tf
+++ b/workspaces/garage-homelab/bucket-terraform-state.tf
@@ -1,0 +1,21 @@
+# This bucket is meant to eventually host this repo's OWN Terraform state (see
+# terraform.tf: every workspace's backend, including this one, still points at
+# the existing MinIO-hosted homelab-terraform-state bucket for now) -- creating
+# it here does not migrate anything. That migration is a deliberate, separate
+# cutover: each workspace's backend block would need to move to this bucket
+# after it exists, and the very first apply that creates it can't itself be
+# backed by it (a state backend can't bootstrap into a bucket the same run is
+# what creates). Disaster recovery is the same story in reverse: recovering
+# this Garage instance from scratch requires getting Terraform state back by
+# some other means before this bucket -- and therefore every other workspace's
+# backend -- can be reached again. Pre-existing risk inherited from the MinIO
+# original, not introduced here; flagging for whoever does the cutover.
+module "terraform_state" {
+  source = "../../modules/garage-bucket"
+
+  bucket_name           = "${local.bucket_prefix}-terraform-state"
+  owner_key_name        = "terraform"
+  bitwarden_project_id  = var.bitwarden_project_id
+  garage_admin_endpoint = var.garage_admin_endpoint
+  garage_admin_token    = var.garage_admin_token
+}

--- a/workspaces/garage-homelab/main.tf
+++ b/workspaces/garage-homelab/main.tf
@@ -1,0 +1,3 @@
+locals {
+  bucket_prefix = "homelab"
+}

--- a/workspaces/garage-homelab/migration-key.tf
+++ b/workspaces/garage-homelab/migration-key.tf
@@ -1,0 +1,89 @@
+# ============================================================================
+# TEMPORARY -- migration-only credential. DELETE THIS FILE WHOLESALE (and
+# `terraform apply`) once the MinIO-to-Garage bucket migration is complete
+# for all four buckets below (clusters#910's runbook, OPERATIONS.md
+# "Runbook: migrate MinIO buckets to Garage"). Leaving it in place afterward
+# is exactly the kind of standing broad-write privilege this project already
+# rejected once, in dropping the Garage operator over its own cluster-wide
+# Secret access -- a migration credential that outlives its migration is the
+# same mistake in miniature.
+# ============================================================================
+#
+# Lives at the workspace level, not inside modules/garage-bucket: it spans
+# all four buckets below rather than belonging to any one of them, and the
+# module's own garage_bucket_permission.owner is the wrong shape for this
+# anyway (owner, not read+write; one bucket, not four).
+#
+# read+write, never owner -- same reasoning as modules/garage-bucket/key.tf's
+# owner permission, checked against what clusters#910's scripts actually do
+# rather than assumed: verify-bucket.sh reads back what it wrote (`rclone
+# size`/`lsf`/`check` against the Garage destination -- LIST + HEAD/ETag
+# comparisons, all read-permission operations) and preflight-canary.sh
+# round-trips a throwaway object (`rcat`/`cat`/`deletefile` -- write already
+# covers object delete in Garage's model, see key.tf). Nothing in
+# clusters#910 ever touches a bucket's own configuration (website access,
+# alias, deletion) -- the one thing `owner` grants beyond `read`+`write` --
+# so `owner` here would be a wider grant than any script can even exercise.
+resource "garage_key" "migration" {
+  name = "minio-garage-migration"
+}
+
+resource "garage_bucket_permission" "migration_authentik_media" {
+  bucket_id     = module.authentik_media.bucket.id
+  access_key_id = garage_key.migration.id
+  read          = true
+  write         = true
+}
+
+resource "garage_bucket_permission" "migration_loki_chunks" {
+  bucket_id     = module.loki_chunks.bucket.id
+  access_key_id = garage_key.migration.id
+  read          = true
+  write         = true
+}
+
+resource "garage_bucket_permission" "migration_loki_ruler" {
+  bucket_id     = module.loki_ruler.bucket.id
+  access_key_id = garage_key.migration.id
+  read          = true
+  write         = true
+}
+
+resource "garage_bucket_permission" "migration_terraform_state" {
+  bucket_id     = module.terraform_state.bucket.id
+  access_key_id = garage_key.migration.id
+  read          = true
+  write         = true
+}
+
+# Bitwarden entry names are the owner's own, created by hand ahead of this
+# PR (cluster_homelab_garage_migration_accesskeyid/_secretkey) -- a
+# deliberate departure from modules/garage-bucket/bitwarden.tf's usual
+# bucket_<name>_accesskey/_secretkey convention, since this key isn't scoped
+# to one bucket and the owner named it first. clusters#910's migration Job
+# envsubsts GARAGE_ACCESS_KEY/GARAGE_SECRET_KEY from these two entries.
+#
+# First-apply note: Garage, not Bitwarden, mints the key ID/secret (see
+# garage_key.migration above), so whatever the owner originally typed into
+# these two entries is not a working credential -- they can only ever have
+# been placeholders reserving the name. `bitwarden_secret` creates a new
+# entry by ID; it does not adopt an existing entry by matching key name. So
+# applying this against an already-populated project produces a SECOND
+# entry with the same key, not an overwrite. Before the first `terraform
+# apply` here: either delete the two hand-created placeholder entries in
+# Bitwarden first, or `terraform import` them into these two resource
+# addresses using their real Bitwarden secret IDs. Do this once, up front --
+# Terraform has no way to detect or warn about the collision on its own.
+resource "bitwarden_secret" "migration_accesskeyid" {
+  key        = "cluster_homelab_garage_migration_accesskeyid"
+  value      = garage_key.migration.id
+  project_id = var.bitwarden_project_id
+  note       = "MinIO->Garage migration key's access key ID -- read+write on homelab-loki-chunks, homelab-loki-ruler, homelab-authentik-media, homelab-terraform-state. Temporary: retire per this file's own top-of-file comment once the migration is done."
+}
+
+resource "bitwarden_secret" "migration_secretkey" {
+  key        = "cluster_homelab_garage_migration_secretkey"
+  value      = garage_key.migration.secret_access_key
+  project_id = var.bitwarden_project_id
+  note       = "MinIO->Garage migration key's secret access key -- read+write on homelab-loki-chunks, homelab-loki-ruler, homelab-authentik-media, homelab-terraform-state. Temporary: retire per this file's own top-of-file comment once the migration is done."
+}

--- a/workspaces/garage-homelab/terraform.tf
+++ b/workspaces/garage-homelab/terraform.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_version = "1.6.6"
+
+  # Deliberately still the MinIO-hosted bucket, not a Garage-hosted one --
+  # backend-hosted state can't bootstrap into a bucket this same workspace is
+  # what creates (see bucket-terraform-state.tf's comment). Migrating this
+  # backend to Garage is a separate, later cutover, not part of provisioning
+  # the bucket itself.
+  backend "s3" {
+    bucket                      = "homelab-terraform-state"
+    key                         = "garage-homelab/terraform.tfstate"
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    force_path_style            = true
+  }
+  required_providers {
+    bitwarden = {
+      source  = "maxlaverse/bitwarden"
+      version = "0.17.6"
+    }
+    garage = {
+      source  = "jkossis/garage"
+      version = "1.0.5"
+    }
+    # Used only by modules/garage-bucket's lifecycle/web-alias REST seams --
+    # see the comments at the top of that module's lifecycle.tf/alias.tf for
+    # why and how to remove it once jkossis/garage gains native support.
+    terracurl = {
+      source  = "devops-rob/terracurl"
+      version = "2.11.0"
+    }
+  }
+}
+
+provider "bitwarden" {
+  experimental {
+    embedded_client = true
+  }
+}
+
+# No explicit endpoint/token args: the garage provider reads GARAGE_ENDPOINT /
+# GARAGE_TOKEN from the environment (same convention as this repo's
+# harbor/authentik/litellm providers). The garage_admin_endpoint /
+# garage_admin_token variables below carry the SAME values into each module
+# call's REST seams, which have no such implicit env var support.
+#
+# Reachability: Garage's admin API (port 3903 on the `garage` Service, namespace
+# garage) has no Ingress today -- only its S3 (3900) and website (3902) ports do
+# (infrastructure/subsystems/storage-core/garage in homelab-ops-kubernetes-apps).
+# That's a deliberate choice in that module (full bucket/key CRUD is a bigger
+# thing to expose publicly than object storage itself), not an oversight here.
+# Reach it via a port-forward before running Terraform:
+#   kubectl --context <homelab context> -n garage port-forward svc/garage 3903:3903
+#   export GARAGE_ENDPOINT="http://localhost:3903"
+#   export GARAGE_TOKEN="<admin-token>"        # Bitwarden key: cluster_homelab_garage_admin_token
+#   export TF_VAR_garage_admin_endpoint="$GARAGE_ENDPOINT"
+#   export TF_VAR_garage_admin_token="$GARAGE_TOKEN"
+provider "garage" {
+}
+
+provider "terracurl" {
+}

--- a/workspaces/garage-homelab/variables.tf
+++ b/workspaces/garage-homelab/variables.tf
@@ -1,0 +1,31 @@
+variable "bitwarden_project_id" {
+  type      = string
+  sensitive = true
+}
+
+# See terraform.tf's provider "garage" block for how to obtain and pass these.
+variable "garage_admin_endpoint" {
+  type = string
+}
+
+variable "garage_admin_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "garage_web_hostname" {
+  description = <<-EOT
+    Hostname Garage's [s3_web] website endpoint actually receives via Ingress for
+    this cluster (garage-web.$${domain_name} in the apps repo's
+    infrastructure/subsystems/storage-core/garage module). Passed through to
+    homelab-authentik-media as its anonymous-read alias.
+
+    Only one bucket in this workspace can use this value -- a deliberate, current
+    choice in the apps-repo module's own [s3_web]/Ingress configuration, not a
+    property of this variable, this workspace, or Terraform, and not a Garage
+    constraint either. It's liftable: see
+    ppat/homelab-ops-kubernetes-apps#3652 for what produces the limit today and
+    what changing it would take. Don't look for the fix here.
+  EOT
+  type        = string
+}


### PR DESCRIPTION
## Summary

MinIO is being replaced with Garage object storage; the operator that would have provisioned Garage buckets/keys was deliberately dropped (ppat/homelab-ops-kubernetes-apps#3639) for granting itself cluster-wide Secret-read access to automate at most one instance. Per the owner's own framing ("terraform provider by some rando instead of an operator by some rando that gives itself cluster wide permissions"), this PR builds bucket/key/permission/lifecycle provisioning here in Terraform, alongside how MinIO's buckets are already managed (`modules/minio-bucket`, `workspaces/minio-{homelab,nas}`).

Adds `modules/garage-bucket` and `workspaces/garage-homelab`, provisioning `homelab-loki-chunks`, `homelab-loki-ruler`, `homelab-authentik-media`, and `homelab-terraform-state`, plus a temporary migration credential for the MinIO→Garage copy job.

**Not applied.** This repo has no CI apply job; the owner runs Terraform manually. **Blocked until `ppat/homelab-ops-kubernetes-clusters#908` merges and Flux reconciles it** — that's the change that actually deploys Garage to the `homelab` cluster; nothing here is reachable before then. (Referencing that PR's outcome rather than its current review status deliberately — a status recorded here goes stale the moment #908 moves; check it directly.)

## Provider decision

Three unofficial community providers exist; none is official. Garage v2.3.0 (what this estate runs) serves `/v2/` — a v1-only provider is a non-starter.

| capability | `Arsolitt/garagehq` | `d0ugal/garage` | `jkossis/garage` (chosen) |
|---|---|---|---|
| Admin API version | v2 | v2 (SDK pinned to upstream's `main-v2` branch — its own repo description says "v1", which is stale/wrong; verified from `go.mod`'s pseudo-version (`v0.0.0-20260423203333-1fad3da9c87b`) matching `main-v2`'s HEAD commit exactly — same hash, same timestamp, "update for garage v2.3.0" — and its Go types (`UpdateBucketWebsiteAccess`, `ApiBucketQuotas`) matching the real v2 OpenAPI schema exactly) | v2 (confirmed directly: every call in `internal/client/client.go` hits `/v2/...`) |
| bucket create/read/**delete** | yes | create/read yes; **`DeleteBucket` is a pure no-op** — clears Terraform state without ever calling Garage's API, so `terraform destroy` silently orphans the real bucket | yes, all real (`client.DeleteBucket` calls `POST /v2/DeleteBucket`) |
| key create/read/delete | yes | yes | yes |
| bucket-key permission (read/write/owner) | yes | yes | yes (`garage_bucket_permission`, wraps `AllowBucketKey`/`DenyBucketKey`) |
| website access (anonymous read) | **not supported at all** | yes (native `UpdateBucketWebsiteAccess`) | yes (native `website_enabled`/`website_index_document`) |
| lifecycle/expiration | via S3-API XML `PUT {bucket}?lifecycle` reusing the **admin bearer token as the S3 request's `Authorization` header** — Garage's S3 API expects SigV4-signed requests, not bearer tokens, so this looks very likely to fail at apply time | same broken-looking pattern as Arsolitt | **not exposed** — bridged via a REST seam to the real native endpoint (see below) |
| bucket alias | create-time only | create-time only | create-time only (single `global_alias`, `RequiresReplace`) |
| auth | ? | bearer token | `endpoint`/`token` provider args or `GARAGE_ENDPOINT`/`GARAGE_TOKEN` env vars |
| maintenance | registry-published, 2 releases (v1.0.0, v1.1.0) | 50 releases, very active | 6 releases, has real acceptance + unit tests, terraform-plugin-framework (current SDK, vs sdk2) |

**Chosen: `jkossis/terraform-provider-garage` (registry: `jkossis/garage`, pinned `1.0.5`).** Website access is a hard requirement (`homelab-authentik-media`), which disqualifies `Arsolitt` outright. Between `d0ugal` and `jkossis`, `d0ugal` has far more releases, but two of its own "capabilities" don't hold up under source inspection: `DeleteBucket` never touches the API at all (real destroy-time state drift), and its lifecycle write path authenticates the S3 API the wrong way (bearer token instead of SigV4) — a checked box that looks unlikely to actually work. I don't want to build the one hard-constrained capability (no-versioning + real expiration) on a foundation I can't verify works. `jkossis` is smaller in scope but everything it claims, it does for real, against the real v2 admin API, with tests.

**Risk, stated plainly:** this is still a single-maintainer provider tracking an API that has broken once before (v1→v2). If it goes unmaintained, Terraform state ends up referencing an unavailable resource type — annoying (re-import into whatever replaces it) but not data loss, since Garage itself keeps the real state. That's the risk the owner already explicitly accepted by preferring this shape over the operator.

## The 7-to-N mapping

Garage's flatter permission model (a key *is* the identity — no separate IAM user/policy/attachment) collapses MinIO's 7 resource types to 2 native ones per bucket:

| MinIO (`minio-bucket`) | Garage (`garage-bucket`) |
|---|---|
| `minio_s3_bucket` | `garage_bucket` |
| `minio_s3_bucket_policy` | **dropped** — Garage has no bucket-policy support; anonymous read goes through `[s3_web]` website config instead (below) |
| `minio_iam_user` | `garage_key` |
| `minio_iam_policy` | **dropped** — folded into the bucket-key permission grant directly |
| `minio_iam_user_policy_attachment` | **dropped** — same |
| `minio_iam_service_account` | **dropped** — `garage_key` itself carries the access/secret keypair |
| `minio_ilm_policy` | **not natively available** — bridged via a REST seam (below) |

Every MinIO construct Garage has no equivalent for is dropped outright here, not shimmed with something that only looks equivalent.

Two capabilities `jkossis/garage` doesn't expose natively — lifecycle/expiration rules, and a second bucket alias (needed for anonymous web read) — are bridged via `terracurl_request` seams straight to Garage's own **native v2 admin API** endpoints (`POST /v2/UpdateBucket`'s `lifecycleRules` field, `POST /v2/AddBucketAlias`), the same seam pattern already established in `modules/litellm-virtual-key/object-permission.tf` for a different provider gap. Every field name and endpoint used here — including the PascalCase lifecycle rule fields (`ID`/`Status`/`Expiration.Days`), which Garage's JSON admin API inherited from its shared XML/S3 lifecycle type — was checked against Garage v2.3.0's own source (`src/api/admin/bucket.rs`, `src/api/common/xml/lifecycle.rs`), not just its OpenAPI spec, which turned out to be a hair less descriptive than the real handler in a couple of spots (e.g. it doesn't even mention `lifecycleRules` in `UpdateBucket`'s human-readable description despite the field being live and functional).

The second-alias one-at-a-time constraint (below) is enforced by Garage itself — `POST /v2/AddBucketAlias` rejects a second bucket claiming an alias already pointed at a different bucket (`src/model/helper/locked.rs`'s `set_global_bucket_alias`) — but only at `terraform apply` time, not `plan` time. Documented as a comment in `alias.tf` directly.

## Reaching the admin API

Garage's admin API (port 3903 on the `garage` Service, namespace `garage`) has **no Ingress today** — only S3 (3900) and the website endpoint (3902) do. That's deliberate in the apps-repo module (a full bucket/key CRUD surface is a bigger thing to expose publicly than object storage itself), not an oversight, and this PR doesn't change it. Once `ppat/homelab-ops-kubernetes-clusters#908` merges and reconciles, Terraform reaches it via `kubectl port-forward` (this repo has no CI apply job; the owner runs Terraform manually, same as every other workspace here):

```bash
kubectl --context <homelab context> -n garage port-forward svc/garage 3903:3903
export GARAGE_ENDPOINT="http://localhost:3903"
export GARAGE_TOKEN="<admin-token>"   # Bitwarden key: cluster_homelab_garage_admin_token
export TF_VAR_garage_admin_endpoint="$GARAGE_ENDPOINT"
export TF_VAR_garage_admin_token="$GARAGE_TOKEN"
export TF_VAR_garage_web_hostname="garage-web.<domain_name for the homelab cluster>"
export TF_VAR_bitwarden_project_id="<same project used by minio-homelab>"
```

This differs from MinIO's workspaces, which run straight against an ingress from the owner's workstation.

## Anonymous read for `homelab-authentik-media`

Garage has no S3 bucket-policy support, so this goes through `[s3_web]` website config instead — a second global alias matching the apps-repo module's own web Ingress host, added via the same REST-seam pattern (`POST /v2/AddBucketAlias`), since `jkossis/garage`'s `garage_bucket` resource only manages one alias.

**Only one bucket across the whole Garage instance can use anonymous read at a time.** That limit is a deliberate, current choice in the apps-repo module's own `[s3_web]`/Ingress configuration — not a property of this Terraform, this seam, or Garage itself — and it's liftable: `ppat/homelab-ops-kubernetes-apps#3652` records what produces it today and what changing it would take. Both variables that reference the limit (`anonymous_read_hostname`, `garage_web_hostname`) point at that issue rather than restating the mechanism, so a reader doesn't go looking for the fix in this repo.

## Region

This PR does not set, assume, or document an S3 region anywhere: `jkossis/garage`'s provider and both REST seams talk exclusively to Garage's bearer-token Admin API, never an S3-signed request, so there is no region concept in scope in this code. Region is entirely the concern of whichever client signs S3 requests against these buckets (Loki, Authentik, the migration Job) — apps-repo/cluster config, out of this PR's scope. (The apps-repo module parameterizes `s3_region` via `garage_s3_region`, with `us-east-1` as this estate's chosen convention for both MinIO and Garage.)

## Migration credential

The owner asked explicitly which Bitwarden secrets this migration needs and whether Terraform produces them. Answering directly: **four entries exist today, and only two of them are this PR's problem.**

- `cluster_homelab_garage_admin_token` / `cluster_homelab_garage_rpc_secret` — consumed by the apps-repo module's own `garage-credentials` `ExternalSecret` (Garage's RPC/admin bootstrap, apps#3639). Not written by Terraform, need nothing from this PR.
- `cluster_homelab_garage_migration_accesskeyid` / `cluster_homelab_garage_migration_secretkey` — created by the owner ahead of this PR, with no producer until now. **This PR adds one.**

`clusters#910`'s migration Job (`rclone copy`, `preflight-canary.sh`, `verify-bucket.sh`) needs a single Garage credential with **read+write across all four buckets in scope** — one key, not four per-bucket ones. Checked what the job's scripts actually do rather than assumed the permission level: `verify-bucket.sh`'s three tiers all read the Garage side back (`rclone size`/`lsf`/`check` — LIST + HEAD/ETag against `dst:`), and `preflight-canary.sh` round-trips a throwaway object (`rcat`/`cat`/`deletefile`). So **read+write, never owner** — nothing in that job ever touches a bucket's own configuration (website access, alias, deletion), the one thing `owner` grants beyond `read`+`write`.

Added in `workspaces/garage-homelab/migration-key.tf`: one `garage_key`, four `garage_bucket_permission` grants (read+write, one per bucket), and two `bitwarden_secret` resources writing to the owner's own two entry names — not this module's usual `bucket_<name>_accesskey`/`_secretkey` shape, since this key isn't scoped to one bucket. Lives at the workspace level, not inside `modules/garage-bucket`, since it spans multiple buckets and the module's own permission resource is shaped for a single-bucket owner grant, not a cross-bucket read+write one.

### ⚠️ Owner action required before the first `terraform apply` — delete the two placeholder Bitwarden entries

This is a prerequisite step with the owner's name on it, not a Terraform concern — Terraform cannot detect or warn about it on its own.

Garage mints the key ID and secret; Bitwarden and Terraform don't. So whatever value the owner originally typed into `cluster_homelab_garage_migration_accesskeyid`/`_secretkey` when creating those two entries **cannot be a functional Garage credential** — it was necessarily a placeholder reserving the name. `bitwarden_secret` creates a new entry by ID; it does not adopt an existing entry by matching key name. Applying this as-is against the already-populated project produces a *second* entry sharing that key name, not an overwrite.

**Before the first `terraform apply` against this file: delete both placeholder entries in Bitwarden.** That's almost certainly the right move rather than `terraform import`, precisely because the values in them were never real credentials to begin with. (`terraform import` remains possible if the owner prefers it for some other reason.) Documented as a comment in `migration-key.tf` itself as well.

**Removable by design, not just by policy:** the file opens with a `DELETE THIS FILE WHOLESALE` banner (same idiom this module already uses for its REST-seam files) naming its own retirement condition — once the migration is done for all four buckets — so the credential doesn't outlive its purpose and become, in miniature, the same standing-privilege problem this project already rejected once by dropping the Garage operator. Deleting the file and re-applying revokes the key at Garage (a real `DeleteKey` call, not a no-op), clears both bucket permissions, and removes both Bitwarden entries. No toggle variable, no flag to remember to flip.

No secret values appear anywhere in this PR, its commit, or this description — access-key/secret-key values are Terraform outputs and Bitwarden contents only, never printed.

## Hard constraints honored

- **No versioning anywhere** — Garage doesn't support it at all, which is part of why it was chosen over today's MinIO (3.25M delete markers, ~44GB against 13.58GB live, because plain `Expiration` on a *versioned* bucket doesn't reclaim anything).
- **Bitwarden secret key names preserved byte-for-byte** from `modules/minio-bucket`'s convention (`bucket_<name>_accesskey`/`_secretkey`), so existing consumers' `ExternalSecret`s (e.g. `homelab-authentik-media`'s in the apps repo) keep working unchanged against the new Garage-backed values.
- **`object_expiration_days` is deliberately unset** on both Loki buckets — their MinIO originals were never under Terraform (nothing to mirror), and Loki's own compactor `retention_period` isn't a number this workspace has visibility into to assert. Revisit if Loki's compactor retention ever needs a bucket-side backstop.

## Known, pre-existing hazard (not solved here)

`homelab-terraform-state` living in the object store Terraform itself manages is a bootstrap/disaster-recovery hazard inherited unchanged from the MinIO original — this workspace's own backend still points at the *existing MinIO* bucket of the same name, not the new Garage one, so creating it here doesn't migrate anything. The migration (moving every workspace's backend over) is a separate, deliberate cutover — this is the moment someone might want to do it, but it's not attempted here.

## Verification

```
terraform fmt -check -recursive         # clean
terraform validate                      # modules/garage-bucket: clean
                                         # workspaces/garage-homelab: clean (one pre-existing
                                         #   bitwarden-provider deprecation warning, identical
                                         #   to every other workspace in this repo)
tflint --config=.tflint.hcl             # clean (all dirs)
checkov --config-file .checkov.yaml     # clean (all dirs)
trivy fs --config trivy.yaml            # clean (all dirs)
pre-commit run --all-files (scoped)     # clean
commitlint (pre-commit's pinned hook)   # clean, single scope (garage-homelab)
```

## Test plan

- [ ] CI lint (terraform validate/fmt, tflint, checkov via pre-commit) passes
- [ ] Commitlint passes
- [ ] Owner reviews the provider choice and REST-seam design before ever running `terraform apply`
- [ ] Blocked until `ppat/homelab-ops-kubernetes-clusters#908` merges and Flux reconciles it on the `homelab` cluster — see "Reaching the admin API" above
- [ ] **Owner, before first apply:** delete the two pre-existing `cluster_homelab_garage_migration_*` Bitwarden placeholder entries — see "⚠️ Owner action required" under "Migration credential" above
- [ ] After the migration (clusters#910) completes: delete `workspaces/garage-homelab/migration-key.tf` wholesale and re-apply to retire the migration credential

🤖 Generated with [Claude Code](https://claude.com/claude-code)
