### PR TITLE
fix(garage-bucket): prefix Bitwarden owner-key names to avoid MinIO collision

### DIFF
--- a/modules/garage-bucket/bitwarden.tf
+++ b/modules/garage-bucket/bitwarden.tf
@@ -1,12 +1,31 @@
+# "garage_" disambiguates from modules/minio-bucket's identical bucket_<name>_accesskey/
+# _secretkey formula. Both minio-homelab and garage-homelab set bucket_prefix = "homelab"
+# and share two bucket names (homelab-authentik-media, homelab-terraform-state), so an
+# unprefixed key here would name-collide with MinIO's live entries. bitwarden_secret
+# creates by ID, not by key name -- it never adopts an existing entry -- so a same-named
+# resource here wouldn't overwrite MinIO's secret, it would either get rejected by
+# Bitwarden as a duplicate key or produce two entries sharing one name that every
+# ExternalSecret resolving by that name can no longer disambiguate. The 30-day
+# Garage-vs-MinIO trial (apps#3611) needs both engines' credentials to exist at once under
+# different names for exactly this reason; cutover is then a postBuild-variable change to
+# whichever consumer's secret-store key name is parameterized (apps#3618's pattern for
+# Loki), not a Bitwarden value edit in place.
+#
+# Hardcoded rather than a module variable: this module has no caller that isn't Garage
+# (every resource here -- garage_key, garage_bucket_permission -- is already Garage-only),
+# so there's no second value this would ever need to be. A required variable would just be
+# a fourth call site (one per bucket-owning module block in workspaces/garage-homelab) that
+# could independently drift or be typo'd; hardcoding it once here makes the collision
+# structurally impossible instead of dependent on every caller remembering to set it.
 resource "bitwarden_secret" "bucket_owner_accesskey" {
-  key        = "bucket_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_accesskey"
+  key        = "bucket_garage_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_accesskey"
   value      = garage_key.owner.id
   project_id = var.bitwarden_project_id
   note       = "${var.bucket_name} bucket's accesskey"
 }
 
 resource "bitwarden_secret" "bucket_owner_secretkey" {
-  key        = "bucket_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_secretkey"
+  key        = "bucket_garage_${replace(var.bucket_name, "/[^a-zA-Z0-9]/", "")}_secretkey"
   value      = garage_key.owner.secret_access_key
   project_id = var.bitwarden_project_id
   note       = "${var.bucket_name} bucket's secretkey"

--- a/workspaces/garage-homelab/migration-key.tf
+++ b/workspaces/garage-homelab/migration-key.tf
@@ -59,9 +59,9 @@ resource "garage_bucket_permission" "migration_terraform_state" {
 # Bitwarden entry names are the owner's own, created by hand ahead of this
 # PR (cluster_homelab_garage_migration_accesskeyid/_secretkey) -- a
 # deliberate departure from modules/garage-bucket/bitwarden.tf's usual
-# bucket_<name>_accesskey/_secretkey convention, since this key isn't scoped
-# to one bucket and the owner named it first. clusters#910's migration Job
-# envsubsts GARAGE_ACCESS_KEY/GARAGE_SECRET_KEY from these two entries.
+# bucket_garage_<name>_accesskey/_secretkey convention, since this key isn't
+# scoped to one bucket and the owner named it first. clusters#910's migration
+# Job envsubsts GARAGE_ACCESS_KEY/GARAGE_SECRET_KEY from these two entries.
 #
 # First-apply note: Garage, not Bitwarden, mints the key ID/secret (see
 # garage_key.migration above), so whatever the owner originally typed into


### PR DESCRIPTION
## The defect

`modules/garage-bucket/bitwarden.tf` (merged in #290, `d49a6a4`) wrote owner
credentials to Bitwarden under the exact same `bucket_<name>_accesskey`/
`_secretkey` formula as `modules/minio-bucket/owner.tf`. Both
`workspaces/minio-homelab` and `workspaces/garage-homelab` set
`bucket_prefix = "homelab"` and share two bucket names
(`homelab-authentik-media`, `homelab-terraform-state`), so applying
`garage-homelab` as merged would target four Bitwarden key names that
already hold **live MinIO credentials** — including the Terraform state
backend every workspace (this one included) depends on.

`bitwarden_secret` creates by ID, never adopts an existing entry by
matching key name, so the outcome is either a rejected apply on the
duplicate key, or two ambiguously-named secrets that every consumer
resolving by name can no longer disambiguate. **Nothing has been applied.
The owner has not run `terraform apply` against this yet.**

## Consumer map (what I checked before touching anything)

| Bucket | In minio-homelab? | In garage-homelab? | Bitwarden key scheme | Consumers found |
|---|---|---|---|---|
| `homelab-authentik-media` | yes | yes | `bucket_<name>_accesskey/_secretkey` (both, pre-fix — **collision**) | apps-repo `infrastructure/subsystems/security-extra/authentik/secrets.yaml` — `ExternalSecret` with a **hardcoded** `remoteRef.key: bucket_homelabauthentikmedia_accesskey/_secretkey` (not parameterized like Loki). Stays pointed at MinIO's entry throughout the trial; unaffected by this fix. |
| `homelab-terraform-state` | yes | yes | same formula — **collision** | No k8s `ExternalSecret` consumer in either the apps or clusters repo. Consumed only by whoever runs `terraform init`/`plan`/`apply` locally, exporting `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from this Bitwarden entry by hand — every workspace's S3 backend (including `garage-homelab`'s own, which deliberately still points at the MinIO bucket) reads it. Highest blast radius of the four: a collision here jeopardizes Terraform's own state access. |
| `homelab-loki-chunks` | no (never under Terraform on the MinIO side — see the file's own comment) | yes | same formula, no MinIO counterpart | Loki's actual production credential is a **third, separate** naming scheme entirely: `cluster_homelab_minio_loki_accesskeyid/_secretkey`, hand-maintained, read via `loki_s3_accesskeyid_key`/`loki_s3_secretkey_key` **postBuild variables** (apps#3618) in `clusters/homelab/kustomizations/infra-observability-core.yaml`. No collision possible; module-generated key is currently unused by anything (cutover would just point the variable at it). |
| `homelab-loki-ruler` | no | yes | same as above | same as above |

`minio-nas` was also checked: `bucket_prefix = "nas"`, bucket names
`nas-cloudnativepg-backups`/`nas-longhorn-backups` — no overlap with
`garage-homelab`'s `homelab-*` names. **No collision there.**

I also found that PR #290's own description states the shared key names were
**deliberate** — "Bitwarden secret key names preserved byte-for-byte from
`modules/minio-bucket`'s convention... so existing consumers' `ExternalSecret`s
keep working unchanged against the new Garage-backed values." That's the root
of the defect: it assumed a same-name overwrite-in-place, which
`bitwarden_secret`'s create-by-ID semantics can't actually do, and it's
incompatible with running a side-by-side trial (both engines' credentials
need to exist at once).

## The fix

`modules/garage-bucket/bitwarden.tf` now writes
`bucket_garage_<name>_accesskey`/`_secretkey` — a `garage_` segment inserted
right after `bucket_`. `modules/minio-bucket` is **untouched**; its entries
keep their exact current names, since MinIO is live and its credentials must
not move.

**Rejected: making the prefix a module input variable.** `garage-bucket` has
no caller that isn't Garage — every resource in it (`garage_key`,
`garage_bucket_permission`) is already Garage-specific — so there's no second
value this would ever need to be. A required variable would just add a
fourth call site (one per `bucket-*.tf` file in `workspaces/garage-homelab`)
that could independently drift or get typo'd, silently reintroducing the
exact collision this PR fixes. Hardcoding it once in the module makes the
collision structurally impossible rather than dependent on every caller
remembering to set it correctly.

**Falsifiability check:** for this scheme to still collide, `minio-bucket`
would need to start writing a `bucket_garage_*`-named key, or a second
Garage-backed module would need to write `bucket_<name>_accesskey` without
the `garage_` segment. Neither exists today, and both modules' formulas are
now visibly distinct at the point of definition rather than only by
convention.

Also updated a stale comment in `workspaces/garage-homelab/migration-key.tf`
that referenced the old (pre-fix) key-naming convention by name.

## Migration credential — unchanged, but confirm before first apply

`workspaces/garage-homelab/migration-key.tf`'s
`cluster_homelab_garage_migration_accesskeyid`/`_secretkey` use a third,
already-distinct naming scheme (`cluster_`-prefixed, workspace-level, spans
all four buckets) — no collision with anything, and no change needed here.

**⚠️ Before the first `terraform apply` against `garage-homelab`:** the owner
must delete the two hand-created placeholder Bitwarden entries at those two
names (or `terraform import` them) — this is unrelated to the fix in this
PR, but it's the other blocking defect in this workspace and is documented
in the file's own comment. `bitwarden_secret` creates by ID and will not
adopt them by matching key name; applying without deleting them first
produces a second, duplicate-keyed entry alongside each placeholder rather
than an overwrite.

## Verification

```
terraform fmt -check -recursive                        # clean
terraform validate (modules/garage-bucket)              # clean
terraform validate (workspaces/garage-homelab)          # clean (one pre-existing
                                                          #   bitwarden-provider deprecation
                                                          #   warning, same as every workspace)
tflint --config=.tflint.hcl                              # clean, both dirs
checkov --config-file .checkov.yaml -d .                 # clean, 16/16 terraform checks passed
pre-commit run --all-files                                # clean (all .ci.env files sourced
                                                          #   together to satisfy every
                                                          #   workspace's provider config)
```

## Test plan

- [ ] CI lint (terraform validate/fmt, tflint, checkov) passes
- [ ] Commitlint passes
- [ ] Owner reviews the chosen scheme before ever running `terraform apply`
- [ ] **Owner, before first apply on `garage-homelab`:** delete (or import)
      the two pre-existing `cluster_homelab_garage_migration_*` Bitwarden
      placeholder entries per `migration-key.tf`'s own comment — unrelated
      to this PR's fix but still blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013euNk932NPhAnZndbfqcir