### PR TITLE
docs(garage-homelab): correct stale garage admin API reachability comments

### DIFF
--- a/modules/garage-bucket/variables.tf
+++ b/modules/garage-bucket/variables.tf
@@ -48,7 +48,7 @@ variable "anonymous_read_hostname" {
 # --- REST seam inputs (lifecycle.tf, alias.tf) ---
 
 variable "garage_admin_endpoint" {
-  description = "Base URL of the Garage Admin API (e.g. http://localhost:3903 via a kubectl port-forward -- see the workspace's terraform.tf for why), used only by the lifecycle/web-alias REST seams. The garage provider itself gets this from the GARAGE_ENDPOINT env var; terracurl has no such implicit config and needs it passed explicitly."
+  description = "Base URL of the Garage Admin API -- reachable via the garage-admin Ingress; see the workspace's terraform.tf for the host and how to set this, and why only /v2 is exposed. Used only by the lifecycle/web-alias REST seams. The garage provider itself gets this from the GARAGE_ENDPOINT env var; terracurl has no such implicit config and needs it passed explicitly."
   type        = string
 }
 

--- a/workspaces/garage-homelab/terraform.tf
+++ b/workspaces/garage-homelab/terraform.tf
@@ -46,17 +46,22 @@ provider "bitwarden" {
 # garage_admin_token variables below carry the SAME values into each module
 # call's REST seams, which have no such implicit env var support.
 #
-# Reachability: Garage's admin API (port 3903 on the `garage` Service, namespace
-# garage) has no Ingress today -- only its S3 (3900) and website (3902) ports do
-# (infrastructure/subsystems/storage-core/garage in homelab-ops-kubernetes-apps).
-# That's a deliberate choice in that module (full bucket/key CRUD is a bigger
-# thing to expose publicly than object storage itself), not an oversight here.
-# Reach it via a port-forward before running Terraform:
-#   kubectl --context <homelab context> -n garage port-forward svc/garage 3903:3903
-#   export GARAGE_ENDPOINT="http://localhost:3903"
+# Reachability: the admin API (port 3903 on the `garage` Service, namespace
+# garage) is reached through the `garage-admin` Ingress
+# (infrastructure/subsystems/storage-core/garage/ingress-admin.yaml in
+# homelab-ops-kubernetes-apps) -- no port-forward needed:
+#   export GARAGE_ENDPOINT="https://garage-admin.${domain_name}"
 #   export GARAGE_TOKEN="<admin-token>"        # Bitwarden key: cluster_homelab_garage_admin_token
 #   export TF_VAR_garage_admin_endpoint="$GARAGE_ENDPOINT"
 #   export TF_VAR_garage_admin_token="$GARAGE_TOKEN"
+#
+# That Ingress deliberately routes only the /v2 path, not /. Every call the
+# garage provider and this workspace's terracurl REST seams
+# (modules/garage-bucket's lifecycle.tf/alias.tf) make is a /v2/... endpoint,
+# so this workspace never loses reachability to anything it needs. Widening
+# the Ingress to `path: /` would also publish Garage's unauthenticated
+# /metrics and /health there -- the /v2 scoping is what keeps those off this
+# hostname, not an oversight to "fix" by broadening it.
 provider "garage" {
 }
 


### PR DESCRIPTION
## The defect

Two comments asserted Garage's admin API has no Ingress and must be reached
via `kubectl port-forward` before running Terraform:

1. `workspaces/garage-homelab/terraform.tf`, the block comment above
   `provider "garage" {}`.
2. `modules/garage-bucket/variables.tf`, the `garage_admin_endpoint`
   variable description (pointed at the same port-forward story).

Both were true when written (PR #290) but are false now: the apps-repo
module gained an admin `Ingress` in `homelab-ops-kubernetes-apps#3656`, and
it reached `homelab` when `infra-storage-core` `v0.5.1` was deployed
(clusters PR #914). Live behavior confirms it: `GET /metrics` on the new
hostname 404s (no matching rule), while `/v2/...` routes through to Garage
-- exactly the split the apps-repo Ingress's own comment documents. Every
call this repo's `garage` provider and its `terracurl` REST seams
(`modules/garage-bucket/lifecycle.tf`, `alias.tf`) make is under `/v2`, so
nothing in this repo needs the excluded `/metrics`/`/health`/`/check` paths.

Leaving the stale comment in place cost real time -- it's why a port-forward
step was still being carried in the apply instructions for no reason.

## The fix

- `terraform.tf`: replaces the port-forward procedure with the
  `garage-admin` Ingress host/URL, and adds why the Ingress is deliberately
  scoped to `/v2` (everything this workspace calls lives there) and what
  widening it would re-expose (unauthenticated `/metrics`, `/health`). Kept
  the still-true `GARAGE_ENDPOINT`/`GARAGE_TOKEN`-vs-`TF_VAR_garage_admin_*`
  distinction unchanged.
- `variables.tf`: drops the stale `http://localhost:3903` example, points at
  `terraform.tf` for the host and the `/v2` reasoning rather than duplicating
  it.

No resource, variable, or provider configuration changed -- comment/
description text only.

## Scope note

Both files needed the same correction, so this is one PR. Scope is
`garage-homelab` because `terraform.tf` carries the substantive explanation
and `variables.tf`'s description is now just a pointer to it -- same
asymmetric-scope call PR #291 made when one file was the root fix and the
other was collateral.

## Verification

```
terraform fmt -check -diff workspaces/garage-homelab/terraform.tf modules/garage-bucket/variables.tf   # clean
terraform validate (modules/garage-bucket)                                                              # clean
terraform validate (workspaces/garage-homelab)                                                           # not run -- .ci.env
                                                                                                           #   deliberately not sourced;
                                                                                                           #   confirmed the same
                                                                                                           #   bitwarden-provider
                                                                                                           #   credential error is
                                                                                                           #   pre-existing on a clean
                                                                                                           #   origin/main checkout too
pre-commit run --files workspaces/garage-homelab/terraform.tf modules/garage-bucket/variables.tf         # clean except the
                                                                                                           #   above; committed with
                                                                                                           #   SKIP=terraform-validate
                                                                                                           #   (same targeted skip PR #280
                                                                                                           #   used for this exact
                                                                                                           #   credential gap)
commitlint (run directly against the commit message)                                                      # clean
```

No `terraform apply` was run.

## Test plan

- [x] `terraform fmt`/`validate` (module), `tflint`, `checkov`, `commitlint` clean
- [ ] CI lint passes

Refs #3611 (tracked in `homelab-ops-kubernetes-apps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)