### PR TITLE
feat(garage-homelab): grant Loki's chunks key access to the ruler bucket too

### DIFF
--- a/workspaces/garage-homelab/loki-shared-key.tf
+++ b/workspaces/garage-homelab/loki-shared-key.tf
@@ -1,0 +1,48 @@
+# ============================================================================
+# Loki's chunks key ALSO covers the ruler bucket -- one shared credential,
+# not two. Revisit if apps#3650 lands: it moves Loki's ruler storage off S3
+# entirely (a local-file sidecar instead), at which point ruler needs no
+# bucket credential at all and this permission has nothing left to grant.
+# ============================================================================
+#
+# Why one key needs both: Loki's Helm chart derives ruler.storage.s3 from the
+# SAME rendered object as common.storage.s3 -- one ExternalSecret, one
+# endpoint/key/secret triplet, wired only to loki.storage.s3.*. Whichever
+# Garage key that ExternalSecret resolves to must therefore reach BOTH
+# homelab-loki-chunks and homelab-loki-ruler, or the bucket it doesn't cover
+# starts silently 403ing -- asymmetrically, since ruler activity is the low
+# -traffic path that's easy to miss. Confirmed live: today's MinIO-hosted
+# ConfigMap/loki (namespace logging) already shares one identical credential
+# across both storage blocks; the Garage side needs to match that shape
+# before Loki can cut over (apps#3611).
+#
+# Why here, not inside modules/garage-bucket: every OTHER bucket in this
+# workspace (homelab-authentik-media, homelab-terraform-state) needs its key
+# scoped to itself ONLY -- least privilege is the reason the one-key
+# -per-bucket module shape exists, and it stays correct for those. Loki is
+# the sole exception, and it needs to stay visibly exceptional: this
+# resource is the one place a reader has to look to see which two buckets
+# share a credential. Generalizing the module itself (a bucket-list
+# variable, or a companion key-creating module) was considered and
+# rejected: it would make the shared case reachable by editing one line
+# inside a module every other bucket also calls -- exactly the accidental
+# -widening this must stay incapable of. One instance of the pattern isn't
+# enough to justify a standing abstraction; extract one if a second turns up.
+#
+# module.loki_chunks's key (not loki_ruler's) is the one reused here: both
+# already exist live in Garage/Bitwarden (provisioned by #290), so reusing
+# one avoids rotating a live credential entirely -- this resource only
+# *adds* a permission, it doesn't touch either module's own key or Bitwarden
+# entries. module.loki_ruler's own key is therefore left in place, now
+# unused: retiring it cleanly needs Terraform's `removed` block (1.7+),
+# which this workspace's pinned 1.6.6 doesn't have. Under 1.6.6 the only way
+# to drop it from state is an out-of-band `terraform state rm` plus manual
+# Garage/Bitwarden cleanup -- an operational step, not a plan-and-apply one.
+# Left as a known, tracked cleanup rather than done silently as a side
+# effect of this change.
+resource "garage_bucket_permission" "loki_chunks_key_on_ruler_bucket" {
+  bucket_id     = module.loki_ruler.bucket.id
+  access_key_id = module.loki_chunks.owner_key.id
+  read          = true
+  write         = true
+}


### PR DESCRIPTION
## What this changes

Adds one `garage_bucket_permission` resource in `workspaces/garage-homelab` (`loki-shared-key.tf`) granting `module.loki_chunks`'s **existing** Garage access key `read`+`write` permission on the `homelab-loki-ruler` bucket, in addition to its own `homelab-loki-chunks` bucket.

**Why:** Loki's Helm chart shares one credential between `common.storage.s3` (chunks) and `ruler.storage.s3` (ruler) — one `ExternalSecret`, one endpoint/key/secret triplet. A key scoped to only one bucket leaves the other silently 403ing once Loki cuts over from MinIO to Garage (apps#3611), and it fails in the worst way: the `ExternalSecret` syncs, the `HelmRelease` installs, chunks work, and only ruler's low-traffic S3 activity ever surfaces it. Confirmed live: today's MinIO-hosted `ConfigMap/loki` (namespace `logging`) already shares one identical credential across both storage blocks — the Garage side needs to match that shape before cutover.

## What this deliberately does NOT change

- **`modules/garage-bucket` is untouched.** The one-key-per-bucket default stays exactly as-is for every other consumer (`homelab-authentik-media`, `homelab-terraform-state`) — least privilege is the reason that shape exists and it's still correct for them. This was a deliberate choice, not an oversight: a module-level change (a bucket-list variable, or a companion key-creating module) would make the "one key, many buckets" case reachable by editing a single line inside a module every other bucket also calls — exactly the kind of accidental widening that should stay impossible. There's also only one instance of this pattern today, not enough to justify a standing abstraction.
- **No existing key, bucket, or Bitwarden entry is touched, renamed, or destroyed.** This is a pure addition: one new `garage_bucket_permission` resource, reusing `module.loki_chunks`'s already-live key/Bitwarden entries by reference.
- **`module.loki_ruler`'s own key is left in place, now unused/superseded** rather than retired. Cleanly dropping it from state needs Terraform's `removed` block (1.7+); this workspace is pinned to `1.6.6`, so the only path under 1.6.6 is an out-of-band `terraform state rm` + manual Garage/Bitwarden cleanup — an operational step, not something a `plan`/`apply` can express. Left as a known, called-out cleanup rather than silently done as a side effect here.
- **Loki's own Kubernetes-side `ExternalSecret`/`HelmRelease` wiring (which of the two Bitwarden entries it actually consumes) is out of scope** — that's a change in `homelab-ops-kubernetes-apps`, not this repo.

## What to check in `terraform plan` before applying

This should show **exactly one resource to add, zero to change, zero to destroy**: `garage_bucket_permission.loki_chunks_key_on_ruler_bucket` (create). If the plan shows anything touching `garage_key.*`, `bitwarden_secret.*`, or any `garage_bucket_permission` other than that one new resource — for any of the four buckets — stop and do not apply; that would mean something about the existing keys moved or is being replaced, which this change is specifically designed to avoid (one of the four buckets is `homelab-terraform-state`).

## Note on urgency (not a design input, just context)

apps#3650 (open, not yet merged) moves Loki's ruler storage off S3 entirely (a local-file sidecar instead of `ruler.storage.s3`). If it lands, ruler stops needing bucket access altogether and the existing per-bucket `loki_ruler` key already covers what's left (nothing). That wouldn't make this change pointless — `modules/garage-bucket`'s shape genuinely couldn't express a shared credential, and leaving an asymmetric 403 armed and unexplained would still have been the wrong thing to ship — but it does mean this may not be urgent to apply.

Refs #3611