### PR TITLE
fix(garage-bucket): prevent silent bucket destroys and clear a permanent website diff

### DIFF
--- a/modules/garage-bucket/bucket.tf
+++ b/modules/garage-bucket/bucket.tf
@@ -8,4 +8,35 @@ resource "garage_bucket" "bucket" {
   # alias needed, see var.anonymous_read_enabled's description).
   website_enabled        = var.anonymous_read_enabled
   website_index_document = var.anonymous_read_enabled ? "index.html" : null
+
+  # global_alias carries RequiresReplace() (jkossis/garage v1.0.5,
+  # internal/provider/bucket_resource.go), and its Read() takes
+  # GlobalAliases[0] off Garage's CRDT alias map -- unordered, so a stray
+  # second alias makes refreshes flip global_alias and force a replace (see
+  # ppat/homelab-ops-terraform#297, where this destroyed nothing only because
+  # the bucket held zero objects). Any RequiresReplace() attribute the
+  # provider misreads can do the same, and a replacement is a destroy.
+  # prevent_destroy turns that plan into a hard error instead of a `yes`
+  # someone skims past.
+  #
+  # Terraform 1.6.6 can't take a variable in prevent_destroy, so this applies
+  # to every caller of this module, not just whichever bucket trips it.
+  # To deliberately destroy/replace a bucket (e.g. decommissioning one):
+  # edit this block to `prevent_destroy = false` in this module's source,
+  # apply the affected workspace(s), then revert this file to
+  # `prevent_destroy = true` in a follow-up commit. The window is open for
+  # every bucket this module provisions, not just the one being destroyed --
+  # keep it short.
+  #
+  # What this does NOT catch: `terraform state rm` followed by a fresh
+  # create, a `-target`ed destroy, direct Garage admin-API deletion, or this
+  # resource/module call being deleted from the calling workspace outright --
+  # verified empirically that with the resource removed from config,
+  # `terraform plan` destroys it with no error. prevent_destroy only holds
+  # "as long as the argument remains set to true in the configuration for
+  # that resource" (Terraform's own docs); once the resource has no
+  # configuration at all, there's nothing left to hold it.
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/modules/garage-bucket/bucket.tf
+++ b/modules/garage-bucket/bucket.tf
@@ -44,7 +44,28 @@ resource "garage_bucket" "bucket" {
   # `-target`ed destroy that excludes this resource from the plan's scope,
   # or direct Garage admin-API deletion -- all bypass Terraform's plan
   # entirely.
+
+  # website_error_document is never set in this module's config, so it
+  # resolves to null -- but the provider's Read() maps Garage's
+  # errorDocument: null back to "" in state, so config and state disagree
+  # forever, on every apply, for every website-enabled bucket
+  # (terraform show -json, observed and recurring after an apply that
+  # already "fixed" it):
+  #   before: { "website_error_document": "",   "website_index_document": "index.html" }
+  #   after:  { "website_error_document": null, "website_index_document": "index.html" }
+  # This is provider empty-string-vs-null normalization, not this module
+  # declining to manage a real setting -- there's no error-document feature
+  # being withheld. ignore_changes states that truth. Left unhandled, a plan
+  # that never comes back clean is exactly the training effect
+  # prevent_destroy above exists to counter: an operator who's used to
+  # skimming past a permanent, meaningless diff is the operator who skims
+  # past the destroy line too.
+  #
+  # If a real error document is ever wanted for a bucket: remove
+  # website_error_document from ignore_changes below first -- otherwise
+  # whatever value config sets will be silently ignored.
   lifecycle {
     prevent_destroy = true
+    ignore_changes  = [website_error_document]
   }
 }

--- a/modules/garage-bucket/bucket.tf
+++ b/modules/garage-bucket/bucket.tf
@@ -28,14 +28,22 @@ resource "garage_bucket" "bucket" {
   # every bucket this module provisions, not just the one being destroyed --
   # keep it short.
   #
-  # What this does NOT catch: `terraform state rm` followed by a fresh
-  # create, a `-target`ed destroy, direct Garage admin-API deletion, or this
-  # resource/module call being deleted from the calling workspace outright --
-  # verified empirically that with the resource removed from config,
-  # `terraform plan` destroys it with no error. prevent_destroy only holds
-  # "as long as the argument remains set to true in the configuration for
-  # that resource" (Terraform's own docs); once the resource has no
-  # configuration at all, there's nothing left to hold it.
+  # MOST IMPORTANT GAP: this does NOT catch the module call for a bucket
+  # (e.g. this whole `module "authentik_media" { ... }` block) being deleted
+  # from the calling workspace -- verified empirically on Terraform 1.6.6,
+  # in a throwaway config, that removing a prevent_destroy-guarded resource
+  # from configuration entirely makes `terraform plan` destroy it with no
+  # error at all (a plain "not in configuration" destroy, exit 0). That's
+  # arguably the single most likely real way a bucket here gets deleted, and
+  # this guard does not stop it. prevent_destroy only holds "as long as the
+  # argument remains set to true in the configuration for that resource"
+  # (Terraform's own docs) -- once the resource has no configuration at all,
+  # there's nothing left to hold it.
+  #
+  # Also does not catch: `terraform state rm` followed by a fresh create, a
+  # `-target`ed destroy that excludes this resource from the plan's scope,
+  # or direct Garage admin-API deletion -- all bypass Terraform's plan
+  # entirely.
   lifecycle {
     prevent_destroy = true
   }

--- a/modules/minio-bucket/bucket.tf
+++ b/modules/minio-bucket/bucket.tf
@@ -1,34 +1,6 @@
 resource "minio_s3_bucket" "bucket" {
   bucket = var.bucket_name
   acl    = "private"
-
-  # bucket is ForceNew (aminueza/minio v3.38.6, minio/resource_minio_s3_bucket.go)
-  # -- same class of risk that hit modules/garage-bucket (ppat/homelab-ops-terraform#297):
-  # any attribute with ForceNew/RequiresReplace turns a provider misread into a
-  # replace, and a replace is a destroy. This bucket backs Loki chunks, CNPG and
-  # Longhorn backups, and the Terraform state backend every workspace reads --
-  # prevent_destroy turns that plan into a hard error instead of a `yes` someone
-  # skims past.
-  #
-  # Terraform 1.6.6 can't take a variable in prevent_destroy, so this applies to
-  # every caller of this module, not just whichever bucket trips it.
-  # To deliberately destroy/replace a bucket (e.g. decommissioning one): edit
-  # this block to `prevent_destroy = false` in this module's source, apply the
-  # affected workspace(s), then revert this file to `prevent_destroy = true` in
-  # a follow-up commit. The window is open for every bucket this module
-  # provisions, not just the one being destroyed -- keep it short.
-  #
-  # What this does NOT catch: `terraform state rm` followed by a fresh create,
-  # a `-target`ed destroy, direct MinIO admin-API/mc deletion, or this
-  # resource/module call being deleted from the calling workspace outright --
-  # verified empirically that with the resource removed from config,
-  # `terraform plan` destroys it with no error. prevent_destroy only holds "as
-  # long as the argument remains set to true in the configuration for that
-  # resource" (Terraform's own docs); once the resource has no configuration at
-  # all, there's nothing left to hold it.
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "minio_s3_bucket_policy" "bucket_policy" {

--- a/modules/minio-bucket/bucket.tf
+++ b/modules/minio-bucket/bucket.tf
@@ -1,6 +1,34 @@
 resource "minio_s3_bucket" "bucket" {
   bucket = var.bucket_name
   acl    = "private"
+
+  # bucket is ForceNew (aminueza/minio v3.38.6, minio/resource_minio_s3_bucket.go)
+  # -- same class of risk that hit modules/garage-bucket (ppat/homelab-ops-terraform#297):
+  # any attribute with ForceNew/RequiresReplace turns a provider misread into a
+  # replace, and a replace is a destroy. This bucket backs Loki chunks, CNPG and
+  # Longhorn backups, and the Terraform state backend every workspace reads --
+  # prevent_destroy turns that plan into a hard error instead of a `yes` someone
+  # skims past.
+  #
+  # Terraform 1.6.6 can't take a variable in prevent_destroy, so this applies to
+  # every caller of this module, not just whichever bucket trips it.
+  # To deliberately destroy/replace a bucket (e.g. decommissioning one): edit
+  # this block to `prevent_destroy = false` in this module's source, apply the
+  # affected workspace(s), then revert this file to `prevent_destroy = true` in
+  # a follow-up commit. The window is open for every bucket this module
+  # provisions, not just the one being destroyed -- keep it short.
+  #
+  # What this does NOT catch: `terraform state rm` followed by a fresh create,
+  # a `-target`ed destroy, direct MinIO admin-API/mc deletion, or this
+  # resource/module call being deleted from the calling workspace outright --
+  # verified empirically that with the resource removed from config,
+  # `terraform plan` destroys it with no error. prevent_destroy only holds "as
+  # long as the argument remains set to true in the configuration for that
+  # resource" (Terraform's own docs); once the resource has no configuration at
+  # all, there's nothing left to hold it.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "minio_s3_bucket_policy" "bucket_policy" {


### PR DESCRIPTION
## Sequencing status: the pending replacement loop is cleared

**Update as of 2026-08-15:** the destroy/recreate loop that motivated this PR
(#297) is confirmed gone. The owner's apply against `garage-homelab`
completed (`3 added, 4 destroyed` -- the bucket's final forced replacement),
and plans since then show `0 to destroy`. #297 is being closed separately
with the full account of what happened.

## Why these two changes are one PR, not two

Both land on `garage_bucket.bucket`'s `lifecycle` block in
`modules/garage-bucket/bucket.tf`, and they're the same objective from two
directions:

1. **A plan that's never clean trains the operator who reads it.** The
   `homelab-authentik-media` bucket also carries a permanent, self-inflicted
   diff on `website_error_document` -- the provider normalizes Garage's
   `null` error-document back to `""` on every `Read`, so config (`null`)
   and state (`""`) disagree forever, on every plan, for every
   website-enabled bucket, even immediately after an apply that "fixed" it.
   An operator used to skimming past that noise because it's meaningless is
   the operator who skims past a destroy line because it's usually
   meaningless too -- which is exactly the failure mode that produced #297
   in the first place. Silencing the noise and hardening the destroy path
   are the same fix.
2. Fixing the noise separately, in a follow-up PR touching the same
   `lifecycle` block, would just conflict with this one.

## Change 1: `prevent_destroy` on `garage_bucket.bucket`

`terraform plan`/`apply` against `workspaces/garage-homelab` recently offered
to destroy and recreate `homelab-authentik-media`, unprompted -- a real
`-/+` replacement in a plan someone was about to type `yes` to. Root cause
(#297, fixed by #298): `garage_bucket.global_alias` carries `RequiresReplace()`,
and the provider's `Read()` takes element 0 off `bucket.GlobalAliases` -- a
list Garage builds by iterating a CRDT map with **no ordering guarantee**.
Two aliases on the bucket meant refreshes could read either one, Terraform
saw drift, and `RequiresReplace()` turned that into a destroy/recreate that
cascaded into every resource holding the bucket's ID. It cost nothing this
time only because the bucket held `objects = 0`.

The alias bug is fixed. **The general hazard isn't**: any attribute with
`RequiresReplace()` on a resource whose provider misreads state can still
turn a routine plan into a destroy. `lifecycle { prevent_destroy = true }`
makes that class of plan fail with a hard error instead of being offered
for approval. The comment on the `lifecycle` block itself carries the
mechanism, the override procedure, and the boundary below -- because
that's what an operator reads mid-incident, not this PR body.

### Scope: `modules/minio-bucket` deliberately not touched

I checked `minio_s3_bucket.bucket` (`aminueza/minio` v3.38.6, the version
this repo pins) and confirmed `bucket` (the name attribute) is `ForceNew` --
the same class of risk as Garage's `global_alias`. That finding stands, but
per the owner's call it's not being acted on here: MinIO is on a
decommission path (Garage is on trial as its successor), so guarding it now
protects a component that may be removed anyway, and if Garage doesn't pan
out the decision gets revisited at that point.

### Scope: `modules/garage-key` also deliberately excluded

`garage_key` resources carry `RequiresReplace()` on *every* attribute and
the provider's `Update()` unconditionally errors, so keys are *more*
replacement-prone than buckets -- but a destroyed key is recoverable: new
credentials land in Bitwarden, `ExternalSecret`s re-sync. A destroyed
bucket is not recoverable. There's also a live `garage_key.migration`
(`workspaces/garage-homelab/migration-key.tf`) that's temporary by design,
meant to be destroyed once the MinIO->Garage migration completes -- guarding
the module would obstruct that planned work. If this reasoning is wrong,
say so.

### Why `prevent_destroy`, and why it touches every caller of this module

Considered and rejected: `ignore_changes = [global_alias]` treats one
symptom and blinds Terraform to genuine alias drift; `check` blocks only
warn, so they gate nothing; a `precondition` cannot express "do not
destroy"; this repo has no CI plan/apply job for a pipeline gate to hook
into.

`prevent_destroy` fails the **plan** with a hard error for both an outright
destroy and a replacement (a replacement contains a destroy) -- it would
have turned the original plan into a stop, not a `yes` to skim past.

The constraint: **`prevent_destroy` cannot take a variable in Terraform
1.6.6** -- it must be a literal, so it can't be made per-caller with a
`var.protect` flag. Every caller of `garage-bucket` gets it (3 buckets
today, all of which matter). The escape hatch is editing the module source,
applying, and reverting -- which affects **every** bucket this module
provisions while the edit is in place, not just the one being destroyed.
That procedure is written on the `lifecycle` block itself so it's
discoverable at the moment it's needed, not only in a README (this module
doesn't have one).

### What `prevent_destroy` does NOT protect against

Be clear-eyed about the boundary, since a false sense of coverage is worse
than none.

**Most important gap, confirmed empirically:** deleting a bucket's `module`
call from the calling workspace (e.g. removing
`module "authentik_media" { ... }` from `workspaces/garage-homelab`)
outright -- this is likely the single most probable real way a bucket here
ends up deleted, and this guard does **not** stop it. In a throwaway
local-backend config on Terraform 1.6.6 (this repo's pinned version), a
`prevent_destroy`-guarded resource removed entirely from configuration
plans a plain, unblocked destroy -- exit 0, no error, just
`# (because ... is not in configuration)`. This matches Terraform's own
documented boundary: `prevent_destroy` holds "as long as the argument
remains set to true in the configuration for that resource"; once the
resource has no configuration at all, there's nothing left to hold it.
(I originally expected this case to fail the plan too -- it doesn't. Worth
flagging since it's counter to the intuitive reading of `prevent_destroy`.)

Also does not catch:

- `terraform state rm` followed by a fresh `create` -- state manipulation
  bypasses lifecycle checks entirely.
- A `-target`ed destroy that excludes the protected resource from the plan's
  scope (Terraform's own error message names this as the escape hatch it
  expects operators to reach for on purpose).
- Direct Garage admin-API deletion -- outside Terraform entirely, invisible
  to this or any Terraform-side control.

### Falsification (not applied against real state)

Real state lives in a live MinIO/S3 backend -- I didn't touch it, and ran
no plan/apply against the real workspaces. Instead, proved the mechanism in
a throwaway config in `/tmp` with a **local backend** and a `null_resource`
standing in for a bucket, on Terraform 1.6.6, then deleted the directory
afterward.

**Replacement case** (the case that actually bit us: resource stays in
config, a `RequiresReplace()`-equivalent attribute changes):

```
╷
│ Error: Instance cannot be destroyed
│
│   on main.tf line 11:
│   11: resource "null_resource" "bucket_stand_in" {
│
│ Resource null_resource.bucket_stand_in has lifecycle.prevent_destroy set,
│ but the plan calls for this resource to be destroyed. To avoid this error
│ and continue with the plan, either disable lifecycle.prevent_destroy or
│ reduce the scope of the plan using the -target flag.
╵
```

`terraform plan` exits 1. Confirmed.

**Explicit destroy case**, resource still declared in config
(`terraform plan -destroy`, i.e. what `terraform destroy` runs): identical
error, identical exit 1.

**Resource removed from configuration entirely:** see "Most important gap"
above -- exit 0, no error.

## Change 2: `ignore_changes = [website_error_document]`

`modules/garage-bucket/bucket.tf` never sets `website_error_document`, so
it resolves to `null` in config. The provider's `Read()` maps Garage's
`errorDocument: null` back to `""` in state, so config and state disagree
forever. Confirmed scoped to website-enabled buckets only --
`loki_chunks`/`terraform_state` (`website_enabled = false`) already plan
clean, since there's nothing to normalize when the website feature isn't
on.

Evidence (`terraform show -json` on a real plan against `homelab-authentik-media`,
run by the owner, recurring on the plan immediately following an apply
that "fixed" it):

```
before: { "website_error_document": "",   "website_index_document": "index.html" }
after:  { "website_error_document": null, "website_index_document": "index.html" }
```

Considered and rejected: hardcoding `website_error_document = ""` in config
to match what the provider reads back. That's fragile in a specific
direction -- if a future provider version fixes its null handling, the
hardcoded `""` becomes a *real* diff the other way -- and it also reads
like a deliberate configuration choice when it's nothing of the sort.
`ignore_changes` states the actual truth: this module doesn't manage that
attribute. The comment on the `lifecycle` block also records the
consequence: if a bucket ever needs a real error document, that argument
has to come out of `ignore_changes` first, or config's value is silently
ignored.

## Validation

- `terraform fmt -check -recursive -diff` from repo root: clean, no diff.
- `terraform init -backend=false` + `terraform validate` in
  `modules/garage-bucket`: succeeds.
- Full pre-commit hook set ran on both commits (fmt, validate, tflint,
  checkov, secret detection): all passed.
- Did not run `terraform plan`/`apply` against any real workspace, per
  instructions -- the backend is live infrastructure.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
